### PR TITLE
Av 1854 fixes for search term and resource reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.6.15'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6.15'
+          python-version: '3.6'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -533,13 +533,14 @@ class ResourceStats(Base):
     def get_top(cls, limit=20):
         resource_stats = []
         # TODO: Reimplement in more efficient manner if needed (using RANK OVER and PARTITION in raw sql)
-        unique_resources = model.Session.query(cls.resource_id, func.count(cls.visits)).group_by(cls.resource_id).order_by(
-            func.count(cls.visits).desc()).join(model.Resource, model.Resource.id == cls.resource_id).limit(limit).all()
+        unique_resources = model.Session.query(cls.resource_id, func.count(cls.visits), func.sum(cls.downloads)).group_by(cls.resource_id).order_by(
+            func.sum(cls.downloads).desc()).having(func.sum(cls.downloads) > 0).join(model.Resource, model.Resource.id == cls.resource_id).limit(limit).all()
         # Adding last date associated to this package stat and filtering out private and deleted packages
         if unique_resources is not None:
             for resource in unique_resources:
                 resource_id = resource[0]
                 visits = resource[1]
+                downloads = resource[2]
                 # TODO: Check if associated resource is private
                 resource = model.Session.query(model.Resource).filter(model.Resource.id == resource_id).filter_by(
                     state='active').first()
@@ -548,9 +549,9 @@ class ResourceStats(Base):
 
                 last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.resource_id == resource_id).first()
 
-                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0], visits=visits)
+                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0], visits=visits, downloads=downloads)
                 resource_stats.append(rs)
-        dictat = ResourceStats.convert_to_dict(resource_stats, None)
+        dictat = ResourceStats.convert_to_dict(resource_stats, None, None)
         return dictat
 
     @classmethod
@@ -670,8 +671,11 @@ class ResourceStats(Base):
                 # Do nothing if date of visit isn't in period of current week
                 if visit_date < current_start_of_week or visit_date > current_end_of_week:
                     continue
-                weekly_download_count += visit.get('downloads', 0)
-                weekly_visit_count += visit.get('visits', 0)
+                
+                if visit.get('downloads', 0) is not None:
+                    weekly_download_count += visit.get('downloads', 0)
+                if visit.get('visits', 0) is not None:
+                    weekly_visit_count += visit.get('visits', 0)
 
             visit_list.append({'year': current_end_of_week.year, 'week': current_end_of_week.isocalendar()[1],
                                'visits': weekly_visit_count, 'downloads': weekly_download_count})
@@ -1075,7 +1079,7 @@ class SearchStats(Base):
 
     @classmethod
     def get_most_popular_search_terms(cls, start_date, end_date, limit=20):
-        results = model.Session.query(cls).filter(cls.date >= start_date).filter(cls.date <= end_date).limit(limit).all()
+        results = model.Session.query(cls).filter(cls.date >= start_date).filter(cls.date <= end_date).all()
         search_term_counts = {}
         for result in results:
             if result.search_term in search_term_counts:

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -533,8 +533,9 @@ class ResourceStats(Base):
     def get_top(cls, limit=20):
         resource_stats = []
         # TODO: Reimplement in more efficient manner if needed (using RANK OVER and PARTITION in raw sql)
-        unique_resources = model.Session.query(cls.resource_id, func.count(cls.visits), func.sum(cls.downloads)).group_by(cls.resource_id).order_by(
-            func.sum(cls.downloads).desc()).having(func.sum(cls.downloads) > 0).join(model.Resource, model.Resource.id == cls.resource_id).limit(limit).all()
+        unique_resources = model.Session.query(cls.resource_id, func.count(cls.visits), func.sum(cls.downloads)).group_by(
+            cls.resource_id).order_by(func.sum(cls.downloads).desc()).having(func.sum(cls.downloads) > 0).join(
+                model.Resource, model.Resource.id == cls.resource_id).limit(limit).all()
         # Adding last date associated to this package stat and filtering out private and deleted packages
         if unique_resources is not None:
             for resource in unique_resources:
@@ -671,7 +672,7 @@ class ResourceStats(Base):
                 # Do nothing if date of visit isn't in period of current week
                 if visit_date < current_start_of_week or visit_date > current_end_of_week:
                     continue
-                
+
                 if visit.get('downloads', 0) is not None:
                     weekly_download_count += visit.get('downloads', 0)
                 if visit.get('visits', 0) is not None:

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -13,7 +13,7 @@
         <em>in {{ h.link_to(topresource.package_name, h.url_for('dataset.read', id=topresource.package_id)) }}</em>
       </td>
       <td>{{ topresource.visit_date }}</td>
-      <td>{{ topresource.visits }}</td>
+      <td>{{ topresource.downloads }}</td>
     </tr>
     {% endfor %}
     </table>

--- a/ckanext/matomo/tests/test_package_stats.py
+++ b/ckanext/matomo/tests/test_package_stats.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_resource_update_downloads(app):
+def test_package_update_downloads(app):
     init_db()
     package_id = '16364c67-251c-45dc-98d9-9e91105d1928'
     stat_date = datetime.strptime('2022-11-10', '%Y-%m-%d')
@@ -20,7 +20,7 @@ def test_resource_update_downloads(app):
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_resource_update_visits(app):
+def test_package_update_visits(app):
     init_db()
     package_id = '16364c67-251c-45dc-98d9-9e91105d1928'
     stat_date = datetime.strptime('2022-11-10', '%Y-%m-%d')

--- a/ckanext/matomo/tests/test_resource_stats.py
+++ b/ckanext/matomo/tests/test_resource_stats.py
@@ -73,7 +73,6 @@ def test_resource_get_top(app):
             ResourceStats.update_downloads(resource_id, stat_date, base_count_downloads - i_resource)
             ResourceStats.update_visits(resource_id, stat_date, base_count_visits - i_resource)
             stat_date = stat_date - timedelta(weeks=1)
-        
 
     top_resources = ResourceStats.get_top()
     resources = top_resources.get('resources')

--- a/ckanext/matomo/tests/test_resource_stats.py
+++ b/ckanext/matomo/tests/test_resource_stats.py
@@ -1,10 +1,9 @@
 import pytest
 import ckan.tests.factories as factories
-from datetime import datetime
+from datetime import datetime, timedelta
 from ckanext.matomo.model import ResourceStats
 from ckanext.matomo.commands import init_db
-import logging
-log = logging.getLogger(__name__)
+import uuid
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -51,3 +50,35 @@ def test_resource_get_download_count_for_dataset_during_last_12_months(app):
     downloads_during_last_12_months = ResourceStats.get_download_count_for_dataset_during_last_12_months(package_id)
 
     assert downloads_during_last_12_months == 26
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_resource_get_top(app):
+    init_db()
+    number_of_resources = 30
+    resource_range = range(0, number_of_resources - 1)
+    resource_ids = [str(uuid.uuid4()) for number in resource_range]
+    base_count_downloads = 40
+    base_count_visits = 40
+    package_id = '06364c67-251c-45dc-98d9-9e91105d1928'
+    factories.Dataset(id=package_id)
+
+    for i_resource in resource_range:
+        stat_date = datetime.strptime('2022-11-10', '%Y-%m-%d')
+        resource_id = resource_ids[i_resource]
+        factories.Resource(id=resource_id, package_id=package_id)
+
+        # Loop for 10 dates with interval -1 week for each
+        for i_day in range(0, 5):
+            ResourceStats.update_downloads(resource_id, stat_date, base_count_downloads - i_resource)
+            ResourceStats.update_visits(resource_id, stat_date, base_count_visits - i_resource)
+            stat_date = stat_date - timedelta(weeks=1)
+        
+
+    top_resources = ResourceStats.get_top()
+    resources = top_resources.get('resources')
+
+    assert resources[0].get('resource_id') == resource_ids[0]
+    assert resources[0].get('downloads') == 200
+    assert resources[5].get('resource_id') == resource_ids[5]
+    assert len(resources) == 20

--- a/ckanext/matomo/tests/test_search_term.py
+++ b/ckanext/matomo/tests/test_search_term.py
@@ -1,5 +1,4 @@
 import pytest
-import ckan.tests.factories as factories
 from datetime import datetime, timedelta
 from ckanext.matomo.model import SearchStats
 from ckanext.matomo.commands import init_db
@@ -13,7 +12,8 @@ def test_search_term_update_count(app):
     search_term = 'SearchTerm'
     stat_date = datetime.strptime('2022-11-10', '%Y-%m-%d')
     SearchStats.update_search_term_count(search_term, stat_date, 10)
-    most_popular_search_terms = SearchStats.get_most_popular_search_terms(stat_date - timedelta(days=1), stat_date + timedelta(days=1))
+    most_popular_search_terms = SearchStats.get_most_popular_search_terms(
+        stat_date - timedelta(days=1), stat_date + timedelta(days=1))
     assert most_popular_search_terms[0].get('count') == 10
     assert most_popular_search_terms[0].get('search_term') == search_term
 
@@ -31,7 +31,9 @@ def test_most_popular_search_term_sorting(app):
             SearchStats.update_search_term_count('{}-{}'.format(search_term_base, term), stat_date, 20 - term)
         stat_date = stat_date - timedelta(days=1)
 
-    most_popular_search_terms = SearchStats.get_most_popular_search_terms(stat_date - timedelta(days=1), stat_date + timedelta(days=32))
-    assert most_popular_search_terms[0].get('count') == 570 # 30 * (20 - 1)
+    most_popular_search_terms = SearchStats.get_most_popular_search_terms(
+        stat_date - timedelta(days=1), stat_date + timedelta(days=32))
+
+    assert most_popular_search_terms[0].get('count') == 570
     assert most_popular_search_terms[0].get('search_term') == '{}-1'.format(search_term_base)
     assert most_popular_search_terms[0].get('count') > most_popular_search_terms[1].get('count')

--- a/ckanext/matomo/tests/test_search_term.py
+++ b/ckanext/matomo/tests/test_search_term.py
@@ -1,0 +1,37 @@
+import pytest
+import ckan.tests.factories as factories
+from datetime import datetime, timedelta
+from ckanext.matomo.model import SearchStats
+from ckanext.matomo.commands import init_db
+import logging
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_search_term_update_count(app):
+    init_db()
+    search_term = 'SearchTerm'
+    stat_date = datetime.strptime('2022-11-10', '%Y-%m-%d')
+    SearchStats.update_search_term_count(search_term, stat_date, 10)
+    most_popular_search_terms = SearchStats.get_most_popular_search_terms(stat_date - timedelta(days=1), stat_date + timedelta(days=1))
+    assert most_popular_search_terms[0].get('count') == 10
+    assert most_popular_search_terms[0].get('search_term') == search_term
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_most_popular_search_term_sorting(app):
+    init_db()
+    search_term_base = 'SearchTerm'
+    stat_date = datetime.strptime('2022-11-10', '%Y-%m-%d')
+
+    # Loop for 31 days
+    for day in range(1, 31):
+        # Loop for 10 searchterm
+        for term in range(1, 11):
+            SearchStats.update_search_term_count('{}-{}'.format(search_term_base, term), stat_date, 20 - term)
+        stat_date = stat_date - timedelta(days=1)
+
+    most_popular_search_terms = SearchStats.get_most_popular_search_terms(stat_date - timedelta(days=1), stat_date + timedelta(days=32))
+    assert most_popular_search_terms[0].get('count') == 570 # 30 * (20 - 1)
+    assert most_popular_search_terms[0].get('search_term') == '{}-1'.format(search_term_base)
+    assert most_popular_search_terms[0].get('count') > most_popular_search_terms[1].get('count')


### PR DESCRIPTION
- Fix resource report to use sum of downloads-field instead of count of visit rows
- Fix search term report not to limit rows returned from database while calculating sum for each term