### PR TITLE
AV-1888: Most & Least viewed dataset reports are now grouped by org

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           # Install ckanext-report
           git clone https://github.com/vrk-kpa/ckanext-report
           pip install -e ckanext-report
-          pip install -r ckanext-report/pip-requirements.txt
+          pip install -r ckanext-report/requirements.txt
       - name: Setup extension (CKAN >= 2.9)
         if: ${{ matrix.ckan-version != '2.8' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,10 @@ jobs:
           pip install -e .
           # Replace default path to CKAN core config file with the one on the container
           sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+          # Install ckanext-report
+          git clone https://github.com/vrk-kpa/ckanext-report
+          pip install -e ckanext-report
+          pip install -r ckanext-report/pip-requirements.txt
       - name: Setup extension (CKAN >= 2.9)
         if: ${{ matrix.ckan-version != '2.8' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8]
+        ckan-version: [2.9, 2.9-py2]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -63,11 +63,6 @@ jobs:
         run: |
           ckan -c test.ini db init
           ckan -c test.ini matomo init_db
-      - name: Setup extension (CKAN < 2.9)
-        if: ${{ matrix.ckan-version == '2.8' }}
-        run: |
-          paster --plugin=ckan db init -c test.ini
-          paster --plugin=ckanext-matomo matomo init_db -c test.ini
       - name: Run tests
         run: pytest --ckan-ini=test.ini --cov=ckanext.matomo --disable-warnings ckanext/matomo/tests
       - name: Coveralls

--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -19,6 +19,10 @@ def get_organization_url(organization):
     if not organization:
         return request.path
     organization_path = "%s/%s" % (request.path, organization)
+    params = dict(list(request.args.items()))
+    time = params.get('time')
+    if time:
+        organization_path = "%s?time=%s" % (organization_path, time)
     return tk.url_for(organization_path)
 
 

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -637,9 +637,9 @@ class ResourceStats(Base):
             model.Group.type == 'organization',
             model.Group.name == organization,
             model.Group.approval_status == 'approved')
-        .order_by(cls.downloads.desc())
-        .limit(limit)
-        .all())
+            .order_by(cls.downloads.desc())
+            .limit(limit)
+            .all())
 
         resource_stats = []
         # Add last date associated to the resource stat

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -183,7 +183,7 @@ class PackageStats(Base):
                              .filter(cls.visit_date >= start_date)
                              .filter(cls.visit_date <= end_date)
                              .group_by(cls.package_id)
-                             .order_by(sorting_direction(func.sum(cls.visits), descending))
+                             .order_by(sorting_direction('total_visits', descending))
                              .limit(limit)
                              .all())
 
@@ -206,7 +206,7 @@ class PackageStats(Base):
         organization,
         start_date=date(2000, 1, 1),
         end_date=datetime.today(),
-        limit=50,
+        limit=20,
         descending=True,
         package_id=None
     ):
@@ -234,14 +234,18 @@ class PackageStats(Base):
         if package_id:
             query = query.filter(cls.package_id == package_id)
 
+        # Ensure we find results in case organization's name and id do not match
+        # i.e. make sure we use org id for the below db query instead of the org name that's in the url
+        organization_id = get_action('organization_show')({}, {'id': organization}).get('id')
+
         visits_by_dataset = (query.join(model.Package, cls.package_id == model.Package.id)
                              .filter(model.Package.state == 'active')
                              .filter(model.Package.private == False)  # noqa: E712
-                             .filter(model.Package.owner_org == organization)
+                             .filter(model.Package.owner_org == organization_id)
                              .filter(cls.visit_date >= start_date)
                              .filter(cls.visit_date <= end_date)
                              .group_by(cls.package_id)
-                             .order_by(sorting_direction(func.sum(cls.visits), descending))
+                             .order_by(sorting_direction('total_visits', descending))
                              .limit(limit)
                              .all())
 
@@ -249,6 +253,7 @@ class PackageStats(Base):
         for dataset in visits_by_dataset:
             datasets.append({
                 "package_name": PackageStats.get_package_name_by_id(dataset.package_id),
+                "package_title_translated": get_action('package_show')({}, {'id': dataset.package_id}).get('title_translated'),
                 "package_id": dataset.package_id,
                 "visits": dataset.total_visits,
                 "entrances": dataset.total_entrances,
@@ -445,15 +450,16 @@ class PackageStats(Base):
         try:
             package = get_action('package_show')({}, {'id': dataset_name})
             if package.get('organization'):
-                return package.get('organization').get('name')
+                # Fetch the whole organization bundle to get access to translated fields
+                return get_action('organization_show')({}, {'id': package.get('organization').get('id')})
             else:
                 return None
         except ObjectNotFound:
             return None
 
     @classmethod
-    def get_organizations_with_most_popular_datasets(cls, start_date, end_date, limit=20):
-        all_packages_result = cls.get_total_visits(start_date, end_date, limit=None)
+    def get_organizations_with_most_popular_datasets(cls, start_date, end_date, descending=True, limit=20):
+        all_packages_result = cls.get_total_visits(start_date, end_date, descending=descending, limit=20)
         organization_stats = {}
         for package in all_packages_result:
             package_id = package["package_id"]
@@ -461,7 +467,9 @@ class PackageStats(Base):
             downloads = package["downloads"]
             entrances = package["entrances"]
 
-            organization_name = cls.get_organization(package_id)
+            organization = cls.get_organization(package_id)
+            organization_name = organization.get('name')
+            organization_title_translated = organization.get('title_translated')
             if organization_name:
                 if (organization_name in organization_stats):
                     organization_stats[organization_name]["visits"] += visits
@@ -469,6 +477,8 @@ class PackageStats(Base):
                     organization_stats[organization_name]["entrances"] += entrances
                 else:
                     organization_stats[organization_name] = {
+                        "organization_name": organization_name,
+                        "organization_title_translated": organization_title_translated,
                         "visits": visits,
                         "downloads": downloads,
                         "entrances": entrances
@@ -476,15 +486,16 @@ class PackageStats(Base):
 
         organization_list = []
         for organization_name, stats in organization_stats.items():
-            organization_list.append(
-                {"organization_name": organization_name,
+            organization_list.append({
+                 "organization_name": stats["organization_name"],
+                 "organization_title_translated": stats["organization_title_translated"],
                  "total_visits": stats["visits"],
                  "total_downloads": stats["downloads"],
                  "total_entrances": stats["entrances"]
                  }
             )
 
-        return sorted(organization_list, key=lambda organization: organization["total_visits"], reverse=True)[:limit]
+        return sorted(organization_list, key=lambda organization: organization["total_visits"], reverse=descending)[:limit]
 
 
 class ResourceStats(Base):
@@ -614,9 +625,9 @@ class ResourceStats(Base):
         return dictat
 
     @classmethod
-    def get_top_downloaded_resources_for_organization(cls, organization, limit=20):
-        # Query for organization specific visitor counts
-        unique_resources = model.Session.query(
+    def get_top_downloaded_resources_for_organization(cls, organization, time, limit=20):
+        # Query for organization specific resource download counts
+        unique_resources = (model.Session.query(
             cls.resource_id, cls.visits, cls.downloads
         ).filter(
             model.Resource.id == cls.resource_id,
@@ -625,7 +636,10 @@ class ResourceStats(Base):
             model.Group.id == model.Package.owner_org,
             model.Group.type == 'organization',
             model.Group.name == organization,
-            model.Group.approval_status == 'approved').order_by(cls.downloads.desc()).limit(limit).all()
+            model.Group.approval_status == 'approved')
+        .order_by(cls.downloads.desc())
+        .limit(limit)
+        .all())
 
         resource_stats = []
         # Add last date associated to the resource stat

--- a/ckanext/matomo/plugin/__init__.py
+++ b/ckanext/matomo/plugin/__init__.py
@@ -89,7 +89,6 @@ class MatomoPlugin(MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
                 reports.matomo_resource_report_info(),
                 reports.matomo_location_report_info(),
                 reports.matomo_dataset_least_popular_report_info(),
-                reports.matomo_organizations_with_most_popular_datasets_info(),
                 reports.matomo_most_popular_search_terms_info()]
 
     # IClick

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -1,6 +1,7 @@
 from ckanext.matomo.model import PackageStats, ResourceStats, AudienceLocationDate, SearchStats
 from datetime import datetime, timedelta
 import ckan.model as model
+from ckanext.report import lib as report
 
 
 try:
@@ -46,127 +47,106 @@ def matomo_dataset_report(organization, time):
     Generates report based on matomo data. number of views per package
     '''
 
-    # Return index page if an organization is not given
+    # Return matomo_organizations_with_most_popular_datasets list if an organization is not given
     if organization is None:
-        return matomo_dataset_report_index()
+        return matomo_organizations_with_most_popular_datasets(time)
 
     start_date, end_date = last_calendar_period(time)
 
     # get package objects corresponding to popular GA content
-    top_packages = PackageStats.get_total_visits_for_organization(
+    most_visited_packages = PackageStats.get_total_visits_for_organization(
         organization,
         start_date=start_date,
         end_date=end_date,
-        limit=None)
-    top_20 = top_packages[:20]
+        limit=20)
 
     return {
-        'table': top_packages,
-        'top': top_20
+        'report_name': 'matomo-dataset',
+        'table': most_visited_packages
     }
 
 
-# Returns the list of organizations that have report data
-def matomo_dataset_report_index():
-    organizations = model.Session.query(model.Group)\
-        .filter(model.Group.type == 'organization')\
-        .filter(model.Group.state == 'active').all()
-    simple_organizations = []
-    # return organizations that have at least 1 dataset
-    for organization in organizations:
-        if organization.packages(limit=1):
-            simple_organizations.append({'title': organization.title, 'name': organization.name})
-    return {'organizations': simple_organizations, 'table': simple_organizations}
+def matomo_time_option_combinations():
+    time_options = ['week', 'month', 'year']
+    for time in time_options:
+        yield {'time': time}
 
 
-def matomo_dataset_option_combinations():
-    options = ['week', 'month', 'year']
-    for option in options:
-        yield {'time': option}
+def matomo_org_and_time_option_combinations():
+    time_options = ['week', 'month', 'year']
+    org_options = report.all_organizations(include_none=True)
+    for org in org_options:
+        for time in time_options:
+            yield {'organization': org, 'time': time}
 
 
 def matomo_dataset_report_info():
     return {
         'name': 'matomo-dataset',
         'title': 'Most popular datasets',
-        'description': 'Matomo showing top datasets with most views',
+        'description': 'Matomo showing top datasets with most views by organization',
         'option_defaults': OrderedDict((('organization', None),
                                         ('time', 'month'),)),
-        'option_combinations': matomo_dataset_option_combinations,
+        'option_combinations': matomo_org_and_time_option_combinations,
         'generate': matomo_dataset_report,
         'template': 'report/dataset_analytics.html',
     }
 
 
-def matomo_dataset_least_popular_report(time):
+def matomo_dataset_least_popular_report(organization, time):
     '''
     Generates report based on matomo data. number of views per package
     '''
 
+    # Return matomo_organizations_with_most_popular_datasets in reverse order list if an organization is not given
+    if organization is None:
+        return matomo_organizations_with_most_popular_datasets(time, descending=False)
+
     start_date, end_date = last_calendar_period(time)
 
     # get package objects corresponding to popular GA content
-    top_packages = PackageStats.get_total_visits(start_date=start_date, end_date=end_date, limit=None, descending=False)
-    top_20 = top_packages[:20]
+    least_visited_packages = PackageStats.get_total_visits_for_organization(
+        organization=organization,
+        start_date=start_date,
+        end_date=end_date,
+        limit=20,
+        descending=False)
 
     return {
-        'table': top_packages,
-        'top': top_20
+        'report_name': 'matomo-dataset-least-popular',
+        'table': least_visited_packages
     }
-
-
-def matomo_dataset_least_popular_option_combinations():
-    options = ['week', 'month', 'year']
-    for option in options:
-        yield {'time': option}
 
 
 def matomo_dataset_least_popular_report_info():
     return {
         'name': 'matomo-dataset-least-popular',
         'title': 'Least popular datasets',
-        'description': 'Matomo showing top datasets with least views',
-        'option_defaults': OrderedDict((('time', 'month'),)),
-        'option_combinations': matomo_dataset_least_popular_option_combinations,
+        'description': 'Matomo showing top datasets with least views by organization',
+        'option_defaults': OrderedDict((('organization', None),
+                                        ('time', 'month'),)),
+        'option_combinations': matomo_org_and_time_option_combinations,
         'generate': matomo_dataset_least_popular_report,
         'template': 'report/dataset_analytics.html',
     }
 
 
-def matomo_resource_report(organization, last):
+def matomo_resource_report(organization, time):
     '''
-    Generates report based on matomo data. number of views per package
+    Generates report based on matomo data. Number of downloads per package (sum of package's resource downloads)
     '''
-    # Return organization list if none chosen
+
+    # Return matomo_organizations_with_most_popular_datasets list if an organization is not given
     if organization is None:
-        return matomo_resource_report_index()
+        return matomo_organizations_with_most_popular_datasets(time)
 
     # Get the most downloaded resources for the organization
-    top_resources = ResourceStats.get_top_downloaded_resources_for_organization(organization, last)
+    most_downloaded_resources = ResourceStats.get_top_downloaded_resources_for_organization(organization, time)
 
     return {
-        'table': top_resources.get("resources"),
-        'value': last,
-        'last': last
+        'report_name': 'matomo-resource',
+        'table': most_downloaded_resources.get("resources")
     }
-
-
-def matomo_resource_report_index():
-    organizations = model.Session.query(model.Group)\
-        .filter(model.Group.type == 'organization')\
-        .filter(model.Group.state == 'active').all()
-    simple_organizations = []
-    # return organizations that have at least 1 dataset
-    for organization in organizations:
-        if organization.packages(limit=1):
-            simple_organizations.append({'title': organization.title, 'name': organization.name})
-    return {'organizations': simple_organizations, 'table': simple_organizations}
-
-
-def matomo_resource_option_combinations():
-    options = [20, 25, 30, 35, 40, 45, 50]
-    for option in options:
-        yield {'last': option}
 
 
 def matomo_resource_report_info():
@@ -175,8 +155,8 @@ def matomo_resource_report_info():
         'title': 'Most popular resources',
         'description': 'Matomo showing most downloaded resources',
         'option_defaults': OrderedDict((('organization', None),
-                                        ('last', 20),)),
-        'option_combinations': matomo_resource_option_combinations,
+                                        ('time', 'month'),)),
+        'option_combinations': matomo_org_and_time_option_combinations,
         'generate': matomo_resource_report,
         'template': 'report/resource_analytics.html'
     }
@@ -228,23 +208,12 @@ def matomo_location_report_info():
     }
 
 
-def matomo_organizations_with_most_popular_datasets(time):
+def matomo_organizations_with_most_popular_datasets(time, descending=True):
     start_date, end_date = last_calendar_period(time)
-    most_popular_organizations = PackageStats.get_organizations_with_most_popular_datasets(start_date, end_date)
+    most_popular_organizations = PackageStats.get_organizations_with_most_popular_datasets(start_date, end_date, descending=descending)
+
     return {
         'table': most_popular_organizations
-    }
-
-
-def matomo_organizations_with_most_popular_datasets_info():
-    return {
-        'name': 'matomo-most-popular-organizations',
-        'title': 'Most popular organizations',
-        'description': 'Matomo showing most popular organizations by visited datasets',
-        'option_defaults': OrderedDict((('time', 'month'),)),
-        'option_combinations': matomo_dataset_option_combinations,
-        'generate': matomo_organizations_with_most_popular_datasets,
-        'template': 'report/organization_analytics.html'
     }
 
 
@@ -262,7 +231,7 @@ def matomo_most_popular_search_terms_info():
         'title': 'Most popular search terms',
         'description': 'Matomo showing most popular search terms',
         'option_defaults': OrderedDict((('time', 'month'),)),
-        'option_combinations': matomo_dataset_option_combinations,
+        'option_combinations': matomo_time_option_combinations,
         'generate': matomo_most_popular_search_terms,
         'template': 'report/search_term_analytics.html'
     }

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -1,6 +1,5 @@
 from ckanext.matomo.model import PackageStats, ResourceStats, AudienceLocationDate, SearchStats
 from datetime import datetime, timedelta
-import ckan.model as model
 from ckanext.report import lib as report
 
 
@@ -210,7 +209,8 @@ def matomo_location_report_info():
 
 def matomo_organizations_with_most_popular_datasets(time, descending=True):
     start_date, end_date = last_calendar_period(time)
-    most_popular_organizations = PackageStats.get_organizations_with_most_popular_datasets(start_date, end_date, descending=descending)
+    most_popular_organizations = PackageStats.get_organizations_with_most_popular_datasets(start_date,
+                                                                                           end_date, descending=descending)
 
     return {
         'table': most_popular_organizations

--- a/ckanext/matomo/templates/report/dataset_analytics.html
+++ b/ckanext/matomo/templates/report/dataset_analytics.html
@@ -1,22 +1,30 @@
 <div>
-
     <!-- Display organization list if none chosen -->
-    {% if data['organizations'] %}
-    <h2>{% trans %}Organizations that have published data{% endtrans %}</h2> 
-
+    {% if options['organization'] == None %}
+    <h2>{% trans %}Organizations that have published data{% endtrans %}</h2>
     <table class="table table-condensed table-bordered table-striped">
       <tr>
-        <th>{%trans %}Organization{% endtrans %}</th>
+        <th>{% trans %}Organization{% endtrans %}</th>
+        <th>{% trans %}Total views{% endtrans %}</th>
+        <th>{% trans %}Initial entrance{% endtrans %}</th>
+        <th>{% trans %}Entrances of total views{% endtrans %}</th>
+        <th>{% trans %}Downloads{% endtrans %}</th>
       </tr>
-      {% for organization in data['organizations'] %}
-      <tr>
-        <td>{{ h.link_to(organization.title, h.get_organization_url(organization=organization.name)) }}</td>
-      </tr>
-      {% endfor %}
-    </table>
+        {% for row in data['table'] %}
+          {% set org_name = row.get('organization_name') %}
+          {% set org_title = h.get_translated(row, 'organization_title') or org_name %}
+          <tr>
+            <td>{{ h.link_to(org_title, h.get_organization_url(org_name)) }}</td>
+            <td>{{ row.get('total_visits') }}</td>
+            <td>{{ row.get('total_entrances') }}</td>
+            {% snippet "report/snippets/entrances_percentage_td.html", total_visits=row.get('total_visits'), total_entrances=row.get('total_entrances') %}
+            <td>{{ row.get('total_downloads') }}</td>
+          </tr>
+        {% endfor %}
+      </table>
     {% else %}
     <!-- Display organization's 20 most popular datasets -->
-      <h2>{% trans %}Most viewed datasets{% endtrans %}</h2> 
+      <h2>{% trans %}Most viewed datasets{% endtrans %}</h2>
       {% if data['table'] %}
       <table class="table table-condensed table-bordered table-striped">
         <tr>
@@ -26,13 +34,14 @@
           <th>{% trans %}Entrances of total views{% endtrans %}</th>
           <th>{% trans %}Downloads{% endtrans %}</th>
         </tr>
-        {% for toppackage in data['top'] %}
+        {% for row in data['table'] %}
+          {% set package_title = h.get_translated(row, 'package_title') or row.get('package_name') %}
           <tr>
-            <td>{{ h.link_to(toppackage.package_name, h.url_for('dataset.read', id=toppackage.package_id)) }}</td>
-            <td>{{ toppackage.visits }}</td>
-            <td>{{ toppackage.entrances }}</td>
-            {% snippet "report/snippets/entrances_percentage_td.html", total_visits=toppackage.visits, total_entrances=toppackage.entrances %}
-            <td>{{ toppackage.downloads }}</td>
+            <td>{{ h.link_to(package_title, h.url_for('dataset.read', id=row.package_id)) }}</td>
+            <td>{{ row.visits }}</td>
+            <td>{{ row.entrances }}</td>
+            {% snippet "report/snippets/entrances_percentage_td.html", total_visits=row.visits, total_entrances=row.entrances %}
+            <td>{{ row.downloads }}</td>
           </tr>
         {% endfor %}
       </table>

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -1,20 +1,29 @@
 <div>
   <!-- Display organization list if none chosen -->
-  {% if data['organizations'] %}
-    <h2>{% trans %}Organizations that have resources{% endtrans %}</h2> 
-
+  {% if options['organization'] == None %}
+    <h2>{% trans %}Organizations that have published data{% endtrans %}</h2>
     <table class="table table-condensed table-bordered table-striped">
       <tr>
-        <th>{%trans %}Organization{% endtrans %}</th>
+        <th>{% trans %}Organization{% endtrans %}</th>
+        <th>{% trans %}Total views{% endtrans %}</th>
+        <th>{% trans %}Initial entrance{% endtrans %}</th>
+        <th>{% trans %}Entrances of total views{% endtrans %}</th>
+        <th>{% trans %}Downloads{% endtrans %}</th>
       </tr>
-      {% for organization in data['organizations'] %}
-      <tr>
-        <td>{{ h.link_to(organization.title, h.get_organization_url(organization=organization.name)) }}</td>
-      </tr>
-      {% endfor %}
-    </table>
+        {% for row in data['table'] %}
+          {% set org_name = row.get('organization_name') %}
+          {% set org_title = h.get_translated(row, 'organization_title') or org_name %}
+          <tr>
+            <td>{{ h.link_to(org_title, h.get_organization_url(org_name)) }}</td>
+            <td>{{ row.get('total_visits') }}</td>
+            <td>{{ row.get('total_entrances') }}</td>
+            {% snippet "report/snippets/entrances_percentage_td.html", total_visits=row.get('total_visits'), total_entrances=row.get('total_entrances') %}
+            <td>{{ row.get('total_downloads') }}</td>
+          </tr>
+        {% endfor %}
+      </table>
   {% else %}
-    <h2>{% trans %}Most downloaded resources{% endtrans %}</h2> 
+    <h2>{% trans %}Most downloaded resources{% endtrans %}</h2>
     {% if data['table'] %}
         <table class="table table-condensed table-bordered table-striped">
     <tr>

--- a/ckanext/matomo/tests/test_resource_stats.py
+++ b/ckanext/matomo/tests/test_resource_stats.py
@@ -5,7 +5,7 @@ from ckanext.matomo.model import ResourceStats
 from ckanext.matomo.commands import init_db
 import uuid
 
-
+@pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
 def test_resource_update_downloads(app):
     init_db()
@@ -18,7 +18,7 @@ def test_resource_update_downloads(app):
     resource_stats = ResourceStats.get(resource_id)
     assert resource_stats.__dict__.get('downloads') == 2
 
-
+@pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
 def test_resource_update_visits(app):
     init_db()
@@ -31,7 +31,7 @@ def test_resource_update_visits(app):
     resource_stats = ResourceStats.get(resource_id)
     assert resource_stats.__dict__.get('visits') == 2
 
-
+@pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
 def test_resource_get_download_count_for_dataset_during_last_12_months(app):
     init_db()
@@ -51,7 +51,7 @@ def test_resource_get_download_count_for_dataset_during_last_12_months(app):
 
     assert downloads_during_last_12_months == 26
 
-
+@pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
 def test_resource_get_top(app):
     init_db()

--- a/ckanext/matomo/tests/test_resource_stats.py
+++ b/ckanext/matomo/tests/test_resource_stats.py
@@ -5,6 +5,7 @@ from ckanext.matomo.model import ResourceStats
 from ckanext.matomo.commands import init_db
 import uuid
 
+
 @pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
 def test_resource_update_downloads(app):
@@ -18,6 +19,7 @@ def test_resource_update_downloads(app):
     resource_stats = ResourceStats.get(resource_id)
     assert resource_stats.__dict__.get('downloads') == 2
 
+
 @pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
 def test_resource_update_visits(app):
@@ -30,6 +32,7 @@ def test_resource_update_visits(app):
     ResourceStats.update_visits(resource_id, stat_date, 2)
     resource_stats = ResourceStats.get(resource_id)
     assert resource_stats.__dict__.get('visits') == 2
+
 
 @pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")
@@ -50,6 +53,7 @@ def test_resource_get_download_count_for_dataset_during_last_12_months(app):
     downloads_during_last_12_months = ResourceStats.get_download_count_for_dataset_during_last_12_months(package_id)
 
     assert downloads_during_last_12_months == 26
+
 
 @pytest.mark.freeze_time('2022-11-11')
 @pytest.mark.usefixtures("clean_db")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 pytest-ckan
 pytest-cov
-pytest-freezegun

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest-ckan
 pytest-cov
+pytest-freezegun


### PR DESCRIPTION
Most and least viewed dataset reports are now grouped by organization and originally present a list of organizations (sorted by most/least total views and when an organization is selected lists selected organization's datasets.

As such the most popular organizations report was removed as both dataset reports essentially present the exact same information when an organization is not selected.