### PR TITLE
AV-1889: Group resources report by organization and change filtering

### DIFF
--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -593,13 +593,16 @@ class ResourceStats(Base):
         return visits
 
     @classmethod
-    def get_stat_counts_by_id_and_date_range(cls, resource_id, start_date=datetime.today() - relativedelta(months=1), end_date=datetime.today()):
-        resource_visits = model.Session.query(cls).filter(cls.resource_id == resource_id,
-                                                          cls.visit_date >= start_date,
-                                                          cls.visit_date <= end_date).all()
-        total_visits = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id).scalar()
-        total_downloads = model.Session.query(func.sum(cls.downloads)).filter(cls.resource_id == resource_id).scalar()
-        return { 'visits': total_visits, 'downloads': total_downloads }
+    def get_stat_counts_by_id_and_date_range(cls, resource_id,
+                                             start_date=datetime.today() - relativedelta(months=1),
+                                             end_date=datetime.today()):
+        total_visits = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id,
+                                                                        cls.visit_date >= start_date,
+                                                                        cls.visit_date <= end_date).scalar()
+        total_downloads = model.Session.query(func.sum(cls.downloads)).filter(cls.resource_id == resource_id,
+                                                                              cls.visit_date >= start_date,
+                                                                              cls.visit_date <= end_date).scalar()
+        return {'visits': total_visits, 'downloads': total_downloads}
 
     @classmethod
     def get_top(cls, limit=20):
@@ -653,10 +656,11 @@ class ResourceStats(Base):
                 resource_id = resource[0]
                 stats = ResourceStats.get_stat_counts_by_id_and_date_range(resource_id, start_date, end_date)
                 last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.resource_id == resource_id,
-                                                         cls.visit_date >= start_date,
-                                                         cls.visit_date <= end_date).first()
+                                                                                 cls.visit_date >= start_date,
+                                                                                 cls.visit_date <= end_date).first()
 
-                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0], visits=stats['visits'], downloads=stats['downloads'])
+                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0],
+                                   visits=stats['visits'], downloads=stats['downloads'])
                 resource_stats.append(rs)
         dictat = ResourceStats.convert_to_dict(resource_stats, None, None)
         return dictat

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -583,6 +583,16 @@ class ResourceStats(Base):
         return [res_name, res_package_name, res_package_id]
 
     @classmethod
+    def get_all_visits_by_id(cls, resource_id):
+        resource_visits = model.Session.query(cls).filter(cls.resource_id == resource_id).all()
+        total_visits = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id).scalar()
+        total_downloads = model.Session.query(func.sum(cls.downloads)).filter(cls.resource_id == resource_id).scalar()
+        visits = {}
+        if total_visits is not None or total_downloads is not None:
+            visits = ResourceStats.convert_to_dict(resource_visits, total_visits, total_downloads)
+        return visits
+
+    @classmethod
     def get_stat_counts_by_id_and_date_range(cls, resource_id, start_date=datetime.today() - relativedelta(months=1), end_date=datetime.today()):
         resource_visits = model.Session.query(cls).filter(cls.resource_id == resource_id,
                                                           cls.visit_date >= start_date,
@@ -744,7 +754,7 @@ class ResourceStats(Base):
 
     @classmethod
     def get_all_visits(cls, id):
-        visits_dict = ResourceStats.get_last_visits_by_id(id)
+        visits_dict = ResourceStats.get_all_visits_by_id(id)
         downloads_count = visits_dict.get('total_downloads', 0)
         visits_count = visits_dict.get('tot_visits', 0)
         visits = visits_dict.get('resources', [])

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+from dateutil.relativedelta import relativedelta
 import json
 
 from sqlalchemy import types, func, Column, ForeignKey, not_, desc
@@ -303,8 +304,6 @@ class PackageStats(Base):
 
     @classmethod
     def get_visit_count_for_dataset_during_last_12_months(cls, package_id):
-        from dateutil.relativedelta import relativedelta
-
         # Returns a list of visits during the last 12 months.
         first_day = datetime.now() - relativedelta(months=12)
         last_day = datetime.now()
@@ -315,8 +314,6 @@ class PackageStats(Base):
 
     @classmethod
     def get_visit_count_for_dataset_during_last_30_days(cls, package_id):
-        from dateutil.relativedelta import relativedelta
-
         # Returns a list of visits during the last 30 days.
         first_day = datetime.now() - relativedelta(days=30)
         last_day = datetime.now()
@@ -586,17 +583,13 @@ class ResourceStats(Base):
         return [res_name, res_package_name, res_package_id]
 
     @classmethod
-    def get_last_visits_by_id(cls, resource_id, num_days=30):
-        start_date = datetime.now() - timedelta(num_days)
-        resource_visits = model.Session.query(cls).filter(cls.resource_id == resource_id).filter(
-            cls.visit_date >= start_date).all()
-        # Returns the total number of visits since the beggining of all times
+    def get_stat_counts_by_id_and_date_range(cls, resource_id, start_date=datetime.today() - relativedelta(months=1), end_date=datetime.today()):
+        resource_visits = model.Session.query(cls).filter(cls.resource_id == resource_id,
+                                                          cls.visit_date >= start_date,
+                                                          cls.visit_date <= end_date).all()
         total_visits = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id).scalar()
         total_downloads = model.Session.query(func.sum(cls.downloads)).filter(cls.resource_id == resource_id).scalar()
-        visits = {}
-        if total_visits is not None or total_downloads is not None:
-            visits = ResourceStats.convert_to_dict(resource_visits, total_visits, total_downloads)
-        return visits
+        return { 'visits': total_visits, 'downloads': total_downloads }
 
     @classmethod
     def get_top(cls, limit=20):
@@ -625,37 +618,35 @@ class ResourceStats(Base):
         return dictat
 
     @classmethod
-    def get_top_downloaded_resources_for_organization(cls, organization, time, limit=20):
-        # Query for organization specific resource download counts
+    def get_top_downloaded_resources_for_organization(cls, organization, start_date, end_date):
+        # Query for organization specific resource ids
         unique_resources = (model.Session.query(
-            cls.resource_id, cls.visits, cls.downloads
+            cls.resource_id
         ).filter(
             model.Resource.id == cls.resource_id,
             model.Package.id == model.Resource.package_id,
             model.Package.state == 'active',
+            model.Resource.state == 'active',
             model.Group.id == model.Package.owner_org,
             model.Group.type == 'organization',
             model.Group.name == organization,
-            model.Group.approval_status == 'approved')
-            .order_by(cls.downloads.desc())
-            .limit(limit)
+            model.Group.approval_status == 'approved',
+            cls.visit_date >= start_date,
+            cls.visit_date <= end_date)
+            .distinct()
+            .order_by(cls.resource_id)
             .all())
-
         resource_stats = []
         # Add last date associated to the resource stat
         if unique_resources:
             for resource in unique_resources:
                 resource_id = resource[0]
-                visits = resource[1]
-                downloads = resource[2]
-                # TODO: Check if associated resource is private
-                resource = model.Session.query(model.Resource).filter(model.Resource.id == resource_id).filter_by(
-                    state='active').first()
-                if resource is None:
-                    continue
-                last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.resource_id == resource_id).first()
+                stats = ResourceStats.get_stat_counts_by_id_and_date_range(resource_id, start_date, end_date)
+                last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.resource_id == resource_id,
+                                                         cls.visit_date >= start_date,
+                                                         cls.visit_date <= end_date).first()
 
-                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0], visits=visits, downloads=downloads)
+                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0], visits=stats['visits'], downloads=stats['downloads'])
                 resource_stats.append(rs)
         dictat = ResourceStats.convert_to_dict(resource_stats, None, None)
         return dictat
@@ -725,8 +716,6 @@ class ResourceStats(Base):
 
     @classmethod
     def get_download_count_for_dataset_during_last_12_months(cls, package_id):
-        from dateutil.relativedelta import relativedelta
-
         # Returns a list of visits during the last 12 months.
         first_day = datetime.now() - relativedelta(months=12)
         last_day = datetime.now()
@@ -737,8 +726,6 @@ class ResourceStats(Base):
 
     @classmethod
     def get_download_count_for_dataset_during_last_30_days(cls, package_id):
-        from dateutil.relativedelta import relativedelta
-
         # Returns a list of visits during the last 30 days.
         first_day = datetime.now() - relativedelta(days=30)
         last_day = datetime.now()
@@ -807,8 +794,6 @@ class ResourceStats(Base):
 
     @classmethod
     def get_visit_count_for_resource_during_last_12_months(cls, resource_id):
-        from dateutil.relativedelta import relativedelta
-
         first_day = datetime.now() - relativedelta(months=12)
         last_day = datetime.now()
 
@@ -818,8 +803,6 @@ class ResourceStats(Base):
 
     @classmethod
     def get_visit_count_for_resource_during_last_30_days(cls, resource_id):
-        from dateutil.relativedelta import relativedelta
-
         first_day = datetime.now() - relativedelta(days=30)
         last_day = datetime.now()
 
@@ -829,8 +812,6 @@ class ResourceStats(Base):
 
     @classmethod
     def get_download_count_for_resource_during_last_12_months(cls, resource_id):
-        from dateutil.relativedelta import relativedelta
-
         first_day = datetime.now() - relativedelta(months=12)
         last_day = datetime.now()
 
@@ -840,8 +821,6 @@ class ResourceStats(Base):
 
     @classmethod
     def get_download_count_for_resource_during_last_30_days(cls, resource_id):
-        from dateutil.relativedelta import relativedelta
-
         first_day = datetime.now() - relativedelta(days=30)
         last_day = datetime.now()
 

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -663,6 +663,8 @@ class ResourceStats(Base):
                                    visits=stats['visits'], downloads=stats['downloads'])
                 resource_stats.append(rs)
         dictat = ResourceStats.convert_to_dict(resource_stats, None, None)
+        dictat['resources'] = sorted(dictat['resources'], key=lambda resource: resource["downloads"], reverse=True)
+
         return dictat
 
     @classmethod

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from collections import OrderedDict
 
+
 # We don't need to mind the end_date time of day as stats update with delay anyways, right?
 def last_week():
     today = datetime.today()

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -2,13 +2,15 @@ from ckanext.matomo.model import PackageStats, ResourceStats, AudienceLocationDa
 from datetime import datetime, timedelta
 from ckanext.report import lib as report
 
+log = __import__('logging').getLogger(__name__)
+
 
 try:
     from ckan.common import OrderedDict
 except ImportError:
     from collections import OrderedDict
 
-
+# We don't need to mind the end_date time of day as stats update with delay anyways, right?
 def last_week():
     today = datetime.today()
     end_date = today - timedelta(days=1)
@@ -139,8 +141,10 @@ def matomo_resource_report(organization, time):
     if organization is None:
         return matomo_organizations_with_most_popular_datasets(time)
 
+    start_date, end_date = last_calendar_period(time)
+
     # Get the most downloaded resources for the organization
-    most_downloaded_resources = ResourceStats.get_top_downloaded_resources_for_organization(organization, time)
+    most_downloaded_resources = ResourceStats.get_top_downloaded_resources_for_organization(organization, start_date, end_date)
 
     return {
         'report_name': 'matomo-resource',

--- a/ckanext/matomo/templates/report/option_time.html
+++ b/ckanext/matomo/templates/report/option_time.html
@@ -9,7 +9,7 @@ default - Default value for this option
     <label for="option-time"> {{ _('Timespan for records') }} </label>
     <select id="option-time" name="time" class="inline js-auto-submit">
         {% for time in ['week', 'month', 'year'] %}
-            <option value="{{time}}" {% if value == time %}selected="selected" {% endif %}> {{time}} </option>
+            <option value="{{time}}" {% if value == time %}selected="selected" {% endif %}> {{ _(time) }} </option>
        {% endfor %}
     </select>
 </span>

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -5,9 +5,6 @@
     <table class="table table-condensed table-bordered table-striped">
       <tr>
         <th>{% trans %}Organization{% endtrans %}</th>
-        <th>{% trans %}Total views{% endtrans %}</th>
-        <th>{% trans %}Initial entrance{% endtrans %}</th>
-        <th>{% trans %}Entrances of total views{% endtrans %}</th>
         <th>{% trans %}Downloads{% endtrans %}</th>
       </tr>
         {% for row in data['table'] %}
@@ -15,9 +12,6 @@
           {% set org_title = h.get_translated(row, 'organization_title') or org_name %}
           <tr>
             <td>{{ h.link_to(org_title, h.get_organization_url(org_name)) }}</td>
-            <td>{{ row.get('total_visits') }}</td>
-            <td>{{ row.get('total_entrances') }}</td>
-            {% snippet "report/snippets/entrances_percentage_td.html", total_visits=row.get('total_visits'), total_entrances=row.get('total_entrances') %}
             <td>{{ row.get('total_downloads') }}</td>
           </tr>
         {% endfor %}
@@ -28,16 +22,16 @@
         <table class="table table-condensed table-bordered table-striped">
     <tr>
       <th>{% trans %}Resource{% endtrans %}</th>
-      <th>{% trans %}Last accessed date{% endtrans %}</th>
       <th>{% trans %}Downloads{% endtrans %}&nbsp({{ _(options['time']) }})</th>
+      <th>{% trans %}Last accessed date{% endtrans %}</th>
     </tr>
         {% for topresource in table %}
       <tr>
         <td>{{ h.link_to(h.truncate(topresource.resource_name, length=50,whole_word=True), h.url_for('dataset_resource.read',id=topresource.package_id,resource_id=topresource.resource_id)) }}<br />
           <em>in {{ h.link_to(topresource.package_name, h.url_for('dataset.read', id=topresource.package_id)) }}</em>
         </td>
-        <td>{{ topresource.visit_date }}</td>
         <td>{{ topresource.downloads }}</td>
+        <td>{{ topresource.visit_date }}</td>
       </tr>
       {% endfor %}
       </table>

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -29,7 +29,7 @@
     <tr>
       <th>{% trans %}Resource{% endtrans %}</th>
       <th>{% trans %}Last accessed date{% endtrans %}</th>
-      <th>{% trans %}Downloads (since recording started){% endtrans %}</th>
+      <th>{% trans %}Downloads{% endtrans %}&nbsp({{ _(options['time']) }})</th>
     </tr>
         {% for topresource in table %}
       <tr>


### PR DESCRIPTION
https://jira.dvv.fi/browse/AV-1889

Most downloaded resources used to be a list of most downloaded resources throughout the system regardless of whose resources they were. This changes the report to list organizations with most downloaded resources and when an organization is selected lists the corresponding organizations resources and their download counts from most downloaded to least downloaded and adds the possibility to filter with time (week, month, year) instead of the previous 20-50 results limit.

This also quite accidentally fixes another issue on resource read page resource download statistics graph. It was supposed to fetch all the resource downloads for said resource but defaulted to max 30 days which obviously always gave odd numbers.

![image](https://user-images.githubusercontent.com/3969176/226683848-60707013-03ca-4229-8850-584bf129a990.png)

![image](https://user-images.githubusercontent.com/3969176/226683875-2be299f0-0eee-4245-bb6f-04aeb785a5f1.png)

PS: Don't mind the conflicting download numbers on org listing vs org's resources listing. They use data from different sources (package_stats vs resource_stats) and while this SHOULD be correct in actual environments I simply tested by adding random data directly into the DB