### PR TITLE
AV-1854: Check validity of report data

### DIFF
--- a/ckanext/matomo/commands.py
+++ b/ckanext/matomo/commands.py
@@ -149,7 +149,7 @@ def fetch(dryrun, since, until):
         date = datetime.datetime.strptime(date_str, DATE_FORMAT)
         for search_term_stats in date_statistics:
             search_term = search_term_stats.get('label', '(not set)')
-            count = search_term_stats.get('nb_hits', 0)
+            count = search_term_stats.get('nb_visits', 0)
 
             try:
                 if dryrun:

--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -107,3 +107,8 @@ def get_download_count_for_resource_during_last_30_days(id):
     from ckanext.matomo.model import ResourceStats
 
     return ResourceStats.get_download_count_for_resource_during_last_30_days(id)
+
+
+def format_date(datestr):
+    date = datetime.date.fromisoformat(datestr)
+    return date.strftime('%d-%m-%Y')

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -1173,7 +1173,11 @@ class SearchStats(Base):
         :param count: Number of times the search term was searched
         :return: True for a successful update, otherwise False
         '''
-        model.Session.add(SearchStats(search_term=search_term, date=date, count=count))
+        row = model.Session.query(cls).filter(cls.search_term == search_term, cls.date == date).first()
+        if row is None:
+            model.Session.add(SearchStats(search_term=search_term, date=date, count=count))
+        else:
+            row.count = count
         model.Session.commit()
         model.Session.flush()
         return True

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -1189,14 +1189,18 @@ class SearchStats(Base):
         for result in results:
             if result.search_term in search_term_counts:
                 search_term_counts[result.search_term]['count'] += result.count
+                if result.date > search_term_counts[result.search_term]['date']:
+                    search_term_counts[result.search_term]['date'] = result.date
             else:
                 search_term_counts[result.search_term] = {'count': result.count}
+                search_term_counts[result.search_term]['date'] = result.date
 
         search_term_list = []
         for search_term, search_term_info in search_term_counts.items():
             search_term_list.append(
                 {"search_term": search_term,
-                 "count": search_term_info['count']
+                 "count": search_term_info['count'],
+                 "latest_search_date": search_term_info['date'].strftime('%Y-%m-%d')
                  }
             )
 

--- a/ckanext/matomo/plugin/__init__.py
+++ b/ckanext/matomo/plugin/__init__.py
@@ -80,6 +80,7 @@ class MatomoPlugin(MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
                 helpers.get_download_count_for_resource_during_last_12_months,
             'get_download_count_for_resource_during_last_30_days': helpers.get_download_count_for_resource_during_last_30_days,
             'get_organization_url': helpers.get_organization_url,
+            'format_date': helpers.format_date
         }
 
     # IReport

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -29,7 +29,7 @@
     <tr>
       <th>{% trans %}Resource{% endtrans %}</th>
       <th>{% trans %}Last accessed date{% endtrans %}</th>
-      <th>{% trans %}Downloads{% endtrans %}&nbsp({{ _(options['time']) }})</th>
+      <th>{% trans %}Downloads{% endtrans %}&nbsp;({{ _(options['time']) }})</th>
     </tr>
         {% for topresource in table %}
       <tr>

--- a/ckanext/matomo/templates/report/search_term_analytics.html
+++ b/ckanext/matomo/templates/report/search_term_analytics.html
@@ -1,15 +1,17 @@
 <div class="module-content">
-  <h2>{% trans %}Most popular search terms{% endtrans %}</h2> 
+  <h2>{% trans %}Most popular search terms{% endtrans %}</h2>
     {% if data['table'] %}
       <table class="table table-condensed table-bordered table-striped">
       <tr>
         <th>{% trans %}Search term{% endtrans %}</th>
         <th>{% trans %}Total searches{% endtrans %}</th>
+        <th>{% trans %}Last searched date{% endtrans %}</th>
       </tr>
-        {% for toppackage in table %}
+        {% for search_term in table %}
           <tr>
-            <td>{{ toppackage.search_term }}</td>
-            <td>{{ toppackage.count }}</td>
+            <td>{{ search_term.search_term }}</td>
+            <td>{{ search_term.count }}</td>
+            <td>{{ h.format_date(search_term.latest_search_date) }}</td>
           </tr>
         {% endfor %}
       </table>


### PR DESCRIPTION
https://jira.dvv.fi/browse/AV-1854

All that was working funky (that I could find) was that the search_terms could be duplicated to the DB on every run (primary key is id, search_term, date even if the id is completely irrelevant and auto incremented so it would never block duplicates) as there was no create or update logic included. 

EDIT: Turns out we used number of hits the search term got (nb_hits) instead of the actual number of searches made (nb_visits) for search_terms count which obviously also resulted in cuckoo results. 

Before:
![nb_visits_vs_nb_hits](https://user-images.githubusercontent.com/3969176/226683109-fc9a5ce8-2fcc-43a4-81aa-4318f74a99ce.png)

After:
![Screenshot 2023-03-21 184816](https://user-images.githubusercontent.com/3969176/226683182-6c07029b-7f13-41be-a3cb-cd8b101260f4.png)
