### PR TITLE
AV-1969: Update report time options texts

### DIFF
--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -1,4 +1,4 @@
-from ckan.plugins.toolkit import render_snippet, config, get_action
+from ckan.plugins.toolkit import render_snippet, config
 import datetime
 from ckan.plugins import toolkit as tk
 from ckanext.matomo.reports import last_calendar_period

--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -1,6 +1,8 @@
-from ckan.plugins.toolkit import render_snippet, config
+from ckan.plugins.toolkit import render_snippet, config, get_action
 import datetime
 from ckan.plugins import toolkit as tk
+from ckanext.matomo.reports import last_calendar_period
+from flask import request
 
 
 def matomo_snippet():
@@ -15,7 +17,6 @@ def matomo_snippet():
 
 # Get the organization specific report url
 def get_organization_url(organization):
-    from flask import request
     if not organization:
         return request.path
     organization_path = "%s/%s" % (request.path, organization)
@@ -107,3 +108,9 @@ def get_download_count_for_resource_during_last_30_days(id):
     from ckanext.matomo.model import ResourceStats
 
     return ResourceStats.get_download_count_for_resource_during_last_30_days(id)
+
+
+def get_date_range():
+    params = dict(list(request.args.items()))
+    time = params.get('time') if params.get('time') else 'month'
+    return last_calendar_period(time)

--- a/ckanext/matomo/plugin/__init__.py
+++ b/ckanext/matomo/plugin/__init__.py
@@ -80,7 +80,7 @@ class MatomoPlugin(MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
                 helpers.get_download_count_for_resource_during_last_12_months,
             'get_download_count_for_resource_during_last_30_days': helpers.get_download_count_for_resource_during_last_30_days,
             'get_organization_url': helpers.get_organization_url,
-            'format_date': helpers.format_date
+            'format_date': helpers.format_date,
             'get_date_range': helpers.get_date_range
         }
 

--- a/ckanext/matomo/plugin/__init__.py
+++ b/ckanext/matomo/plugin/__init__.py
@@ -80,6 +80,7 @@ class MatomoPlugin(MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
                 helpers.get_download_count_for_resource_during_last_12_months,
             'get_download_count_for_resource_during_last_30_days': helpers.get_download_count_for_resource_during_last_30_days,
             'get_organization_url': helpers.get_organization_url,
+            'get_date_range': helpers.get_date_range
         }
 
     # IReport

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -15,7 +15,7 @@ except ImportError:
 # Set end_date explicitly to be the second before midnight on previous day
 # and start_date to be at 00:00:00 week, month or year from that
 # Example on 2023-03-21 14:11:42
-# week = 2023-03-13 00:00:00 - 2023-03-20 23:59:59
+# week = 2023-03-14 00:00:00 - 2023-03-20 23:59:59
 # month = 2023-02-20 00:00:00 - 2023-03-20 23:59:59
 # year = 2022-03-20 00:00:00 - 2023-03-20 23:59:59
 def last_week():

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -1,5 +1,6 @@
 from ckanext.matomo.model import PackageStats, ResourceStats, AudienceLocationDate, SearchStats
 from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 from ckanext.report import lib as report
 
 log = __import__('logging').getLogger(__name__)
@@ -11,25 +12,30 @@ except ImportError:
     from collections import OrderedDict
 
 
-# We don't need to mind the end_date time of day as stats update with delay anyways, right?
+# Set end_date explicitly to be the second before midnight on previous day
+# and start_date to be at 00:00:00 week, month or year from that
+# Example on 2023-03-21 14:11:42
+# week = 2023-03-13 00:00:00 - 2023-03-20 23:59:59
+# month = 2023-02-20 00:00:00 - 2023-03-20 23:59:59
+# year = 2022-03-20 00:00:00 - 2023-03-20 23:59:59
 def last_week():
     today = datetime.today()
-    end_date = today - timedelta(days=1)
-    start_date = end_date - timedelta(days=7)
+    end_date = today - relativedelta(days=1, hour=23, minute=59, second=59)
+    start_date = end_date - relativedelta(weeks=1, hour=0, minute=0, second=0)
     return start_date, end_date
 
 
 def last_month():
     today = datetime.today()
-    end_date = today - timedelta(days=1)
-    start_date = end_date - timedelta(days=30)
+    end_date = today - relativedelta(days=1, hour=23, minute=59, second=59)
+    start_date = end_date - relativedelta(months=1, hour=0, minute=0, second=0)
     return start_date, end_date
 
 
 def last_year():
     today = datetime.today()
-    end_date = today - timedelta(days=1)
-    start_date = end_date - timedelta(days=365)
+    end_date = today - relativedelta(days=1, hour=23, minute=59, second=59)
+    start_date = end_date - relativedelta(years=1, hour=0, minute=0, second=0)
     return start_date, end_date
 
 

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -21,7 +21,7 @@ except ImportError:
 def last_week():
     today = datetime.today()
     end_date = today - relativedelta(days=1, hour=23, minute=59, second=59)
-    start_date = end_date - relativedelta(weeks=1, hour=0, minute=0, second=0)
+    start_date = today - relativedelta(weeks=1, hour=0, minute=0, second=0)
     return start_date, end_date
 
 

--- a/ckanext/matomo/templates/report/dataset_analytics.html
+++ b/ckanext/matomo/templates/report/dataset_analytics.html
@@ -1,7 +1,10 @@
 <div>
+    {% set start_date, end_date = h.get_date_range() %}
     <!-- Display organization list if none chosen -->
     {% if options['organization'] == None %}
-    <h2>{% trans %}Organizations that have published data{% endtrans %}</h2>
+    <h2>{% trans %}Organizations that have published data{% endtrans %}
+      <span class="h4">({{start_date.strftime('%d.%m.%Y')}} - {{end_date.strftime('%d.%m.%Y')}})</span>
+    </h2>
     <table class="table table-condensed table-bordered table-striped">
       <tr>
         <th>{% trans %}Organization{% endtrans %}</th>

--- a/ckanext/matomo/templates/report/dataset_analytics.html
+++ b/ckanext/matomo/templates/report/dataset_analytics.html
@@ -27,7 +27,9 @@
       </table>
     {% else %}
     <!-- Display organization's 20 most popular datasets -->
-      <h2>{% trans %}Most viewed datasets{% endtrans %}</h2>
+      <h2>{% trans %}Most viewed datasets{% endtrans %}
+        <span class="h4">({{start_date.strftime('%d.%m.%Y')}} - {{end_date.strftime('%d.%m.%Y')}})</span>
+      </h2>
       {% if data['table'] %}
       <table class="table table-condensed table-bordered table-striped">
         <tr>

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -1,7 +1,10 @@
 <div>
+  {% set start_date, end_date = h.get_date_range() %}
   <!-- Display organization list if none chosen -->
   {% if options['organization'] == None %}
-    <h2>{% trans %}Organizations that have published data{% endtrans %}</h2>
+  <h2>{% trans %}Organizations that have published data{% endtrans %}
+    <span class="h4">({{start_date.strftime('%d.%m.%Y')}} - {{end_date.strftime('%d.%m.%Y')}})</span>
+  </h2>
     <table class="table table-condensed table-bordered table-striped">
       <tr>
         <th>{% trans %}Organization{% endtrans %}</th>

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -26,7 +26,9 @@
         {% endfor %}
       </table>
   {% else %}
-    <h2>{% trans %}Most downloaded resources{% endtrans %}</h2>
+    <h2>{% trans %}Most downloaded resources{% endtrans %}
+      <span class="h4">({{start_date.strftime('%d.%m.%Y')}} - {{end_date.strftime('%d.%m.%Y')}})</span>
+    </h2>
     {% if data['table'] %}
         <table class="table table-condensed table-bordered table-striped">
     <tr>

--- a/ckanext/matomo/templates/report/search_term_analytics.html
+++ b/ckanext/matomo/templates/report/search_term_analytics.html
@@ -1,5 +1,8 @@
 <div class="module-content">
-  <h2>{% trans %}Most popular search terms{% endtrans %}</h2> 
+  {% set start_date, end_date = h.get_date_range() %}
+  <h2>{% trans %}Most popular search terms{% endtrans %}
+    <span class="h4">({{start_date.strftime('%d.%m.%Y')}} - {{end_date.strftime('%d.%m.%Y')}})</span>
+  </h2>
     {% if data['table'] %}
       <table class="table table-condensed table-bordered table-striped">
       <tr>


### PR DESCRIPTION
https://jira.dvv.fi/browse/AV-1969

This updates the time option texts from week, month, year to past week, past month, past year (via translations in ytp_main translations.py) and the actual date ranges to use relativedelta  - week, -month and -year instead of -7 days, -30 days, -365 days respectively. 

I also added an unrequested change in form of explicit date range mention in the UI to avoid confusion with ambiguity of statements like last week, past week, previous week etc. Current implementation is set to be from second before midnight YESTERDAY to 00:00:00 a WEEK/MONTH/YEAR from that. 

Example on 2023-03-21 14:11:42
week = 2023-03-13 00:00:00 - 2023-03-20 23:59:59
month = 2023-02-20 00:00:00 - 2023-03-20 23:59:59
year = 2022-03-20 00:00:00 - 2023-03-20 23:59:59

Is this correct or incorrect behaviour? Technically that's not a week since it includes twice the weekday which happened to be yesterday. I.e. 13th of march 2023 was a monday and 20th was a monday. Should it instead be from tuesday 14th 00:00:00 to monday 20th 23:59:59?

In month and year it's more sensible I guess as it was discussed to be date to date a month or a year previous unless I recall that incorrectly.