### PR TITLE
AV-1968: Add years from current to 2014 as time options

### DIFF
--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -1,7 +1,7 @@
 from ckan.plugins.toolkit import render_snippet, config
 import datetime
 from ckan.plugins import toolkit as tk
-from ckanext.matomo.reports import last_calendar_period
+from ckanext.matomo.reports import last_calendar_period, get_report_years
 from flask import request
 
 
@@ -119,3 +119,7 @@ def get_date_range():
     params = dict(list(request.args.items()))
     time = params.get('time') if params.get('time') else 'month'
     return last_calendar_period(time)
+
+
+def get_years():
+    return [str(year) for year in get_report_years()]

--- a/ckanext/matomo/plugin/__init__.py
+++ b/ckanext/matomo/plugin/__init__.py
@@ -81,7 +81,8 @@ class MatomoPlugin(MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
             'get_download_count_for_resource_during_last_30_days': helpers.get_download_count_for_resource_during_last_30_days,
             'get_organization_url': helpers.get_organization_url,
             'format_date': helpers.format_date,
-            'get_date_range': helpers.get_date_range
+            'get_date_range': helpers.get_date_range,
+            'get_years': helpers.get_years
         }
 
     # IReport

--- a/ckanext/matomo/templates/report/option_time.html
+++ b/ckanext/matomo/templates/report/option_time.html
@@ -8,7 +8,8 @@ default - Default value for this option
 <span class="form-select control-group control-organization">
     <label for="option-time"> {{ _('Timespan for records') }} </label>
     <select id="option-time" name="time" class="inline js-auto-submit">
-        {% for time in ['week', 'month', 'year'] %}
+        {% set time_options = ['week', 'month', 'year'] + h.get_years() %}
+        {% for time in time_options %}
             <option value="{{time}}" {% if value == time %}selected="selected" {% endif %}> {{ _(time) }} </option>
        {% endfor %}
     </select>


### PR DESCRIPTION
https://jira.dvv.fi/browse/AV-1968

This adds years from current year to service launch year 2014 as selectable time options for reports

![image](https://user-images.githubusercontent.com/3969176/226978768-46f5c0db-bbce-4e4a-ac0a-30143a32eefc.png)
