### PR TITLE
Org grouped reports should always show all datasets and resources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: ruff
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2]
+        ckan-version: [2.9]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  lint:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -9,14 +9,12 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install requirements
-        run: pip install flake8 pycodestyle
-      - name: Check syntax
-        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
-      - name: Run flake8
-        run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
+        run: pip install ruff
+      - name: Run ruff
+        run: ruff check --format=github ckan
 
   test:
-    needs: lint
+    needs: ruff
     strategy:
       matrix:
         ckan-version: [2.9, 2.9-py2]
@@ -46,7 +44,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install requirements
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install requirements
         run: pip install ruff
       - name: Run ruff
-        run: ruff check --format=github ckan
+        run: ruff check --format=github .
 
   test:
     needs: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.259'
+    hooks:
+      - id: ruff

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta
-from typing import Dict
+from typing import Dict, Optional
 
 from sqlalchemy import types, func, Column, ForeignKey, not_, desc
 from sqlalchemy.orm import relationship
@@ -587,8 +587,14 @@ class ResourceStats(Base):
 
     @classmethod
     def get_stat_counts_by_id_and_date_range(cls, resource_id: str,
-                                             start_date: datetime = datetime.today() - relativedelta(months=1),
-                                             end_date: datetime = datetime.today()) -> Dict[str, int]:
+                                             start_date: Optional[datetime] = None,
+                                             end_date: Optional[datetime] = None) -> Dict[str, int]:
+
+        if not start_date:
+            start_date = datetime.today() - relativedelta(months=1, hour=0, minute=0, second=0, microsecond=0)
+        if not end_date:
+            end_date = datetime.today().replace(hour=23, minute=59, second=59, microsecond=999999)
+
         total_visits: int = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id,
                                                                         cls.visit_date >= start_date,
                                                                         cls.visit_date <= end_date).scalar()

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta
-import json
 from typing import Dict
 
 from sqlalchemy import types, func, Column, ForeignKey, not_, desc
@@ -8,7 +7,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 
 import ckan.model as model
-from ckan.plugins.toolkit import config, aslist, get_action, ObjectNotFound
+from ckan.plugins.toolkit import get_action, ObjectNotFound
 from ckanext.report.helpers import organization_list as get_organizations_with_datasets
 
 
@@ -568,8 +567,10 @@ class ResourceStats(Base):
     def get_resource_info_by_id(cls, resource_id):
         resource = get_action('resource_show')({}, {'id': resource_id})
         package = get_action('package_show')({}, {'id': resource.get('package_id')})
-        result = {'resource_id': resource.get('id'), 'resource_name': resource.get('name'), 'resource_name_translated': resource.get('name_translated'),
-                  'package_id': package.get('id'), 'package_name': package.get('name'), 'package_title': package.get('title'), 'package_title_translated': package.get('title_translated')}
+        result = {'resource_id': resource.get('id'), 'resource_name': resource.get('name'),
+                  'resource_name_translated': resource.get('name_translated'), 'package_id': package.get('id'),
+                  'package_name': package.get('name'), 'package_title': package.get('title'),
+                  'package_title_translated': package.get('title_translated')}
 
 
         return result

--- a/ckanext/matomo/model.py
+++ b/ckanext/matomo/model.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta
 import json
+from typing import Dict
 
 from sqlalchemy import types, func, Column, ForeignKey, not_, desc
 from sqlalchemy.orm import relationship
@@ -8,6 +9,7 @@ from sqlalchemy.ext.declarative import declarative_base
 
 import ckan.model as model
 from ckan.plugins.toolkit import config, aslist, get_action, ObjectNotFound
+from ckanext.report.helpers import organization_list as get_organizations_with_datasets
 
 
 log = __import__('logging').getLogger(__name__)
@@ -234,11 +236,12 @@ class PackageStats(Base):
         if package_id:
             query = query.filter(cls.package_id == package_id)
 
-        # Ensure we find results in case organization's name and id do not match
-        # i.e. make sure we use org id for the below db query instead of the org name that's in the url
-        organization_id = get_action('organization_show')({}, {'id': organization}).get('id')
+        # Get all organization's datasets via organization_show
+        organization = get_action('organization_show')({}, {'id': organization, 'include_datasets': True})
+        organization_id = organization.get('id')
+        datasets = organization.get('packages')
 
-        visits_by_dataset = (query.join(model.Package, cls.package_id == model.Package.id)
+        visits = (query.join(model.Package, cls.package_id == model.Package.id)
                              .filter(model.Package.state == 'active')
                              .filter(model.Package.private == False)  # noqa: E712
                              .filter(model.Package.owner_org == organization_id)
@@ -248,18 +251,24 @@ class PackageStats(Base):
                              .order_by(sorting_direction('total_visits', descending))
                              .all())
 
-        datasets = []
-        for dataset in visits_by_dataset:
-            datasets.append({
-                "package_name": PackageStats.get_package_name_by_id(dataset.package_id),
-                "package_title_translated": get_action('package_show')({}, {'id': dataset.package_id}).get('title_translated'),
-                "package_id": dataset.package_id,
-                "visits": dataset.total_visits,
-                "entrances": dataset.total_entrances,
-                "downloads": dataset.total_downloads,
+        visits_by_dataset = {dataset_id: {'visits': visits, 'entrances': entrances, 'downloads': downloads}
+                             for dataset_id, visits, entrances, downloads in visits}
+
+        # Map the visit data onto relevant datasets
+        result = []
+        for dataset in datasets:
+            id = dataset.get('id')
+            visit = visits_by_dataset.get(id, {})
+            result.append({
+                "package_name": dataset.get('name'),
+                "package_title_translated": dataset.get('title_translated'),
+                "package_id": id,
+                "visits": visit.get('visits', 0),
+                "entrances": visit.get('entrances', 0),
+                "downloads": visit.get('downloads', 0)
             })
 
-        return datasets
+        return sorted(result, key=lambda dataset: dataset["visits"], reverse=descending)
 
     @classmethod
     def get_visits_during_year(cls, resource_id, year):
@@ -445,8 +454,7 @@ class PackageStats(Base):
         try:
             package = get_action('package_show')({}, {'id': dataset_name})
             if package.get('organization'):
-                # Fetch the whole organization bundle to get access to translated fields
-                return get_action('organization_show')({}, {'id': package.get('organization').get('id')})
+                return {'name': package.get('organization').get('name')}
             else:
                 return None
         except ObjectNotFound:
@@ -455,6 +463,7 @@ class PackageStats(Base):
     @classmethod
     def get_organizations_with_most_popular_datasets(cls, start_date, end_date, descending=True):
         all_packages_result = cls.get_total_visits(start_date, end_date, descending=descending)
+        organizations_with_datasets = get_organizations_with_datasets(only_orgs_with_packages=True)
         organization_stats = {}
         for package in all_packages_result:
             package_id = package["package_id"]
@@ -464,7 +473,6 @@ class PackageStats(Base):
 
             organization = cls.get_organization(package_id)
             organization_name = organization.get('name')
-            organization_title_translated = organization.get('title_translated')
             if organization_name:
                 if (organization_name in organization_stats):
                     organization_stats[organization_name]["visits"] += visits
@@ -473,23 +481,24 @@ class PackageStats(Base):
                 else:
                     organization_stats[organization_name] = {
                         "organization_name": organization_name,
-                        "organization_title_translated": organization_title_translated,
                         "visits": visits,
                         "downloads": downloads,
                         "entrances": entrances
                     }
 
         organization_list = []
-        for organization_name, stats in organization_stats.items():
+        for organization in organizations_with_datasets:
+            org_name = organization.get('name')
+            stats = organization_stats.get(org_name, {})
+
             organization_list.append({
-                 "organization_name": stats["organization_name"],
-                 "organization_title_translated": stats["organization_title_translated"],
-                 "total_visits": stats["visits"],
-                 "total_downloads": stats["downloads"],
-                 "total_entrances": stats["entrances"]
+                 "organization_name": org_name,
+                 "organization_title_translated": organization.get('title_translated'),
+                 "total_visits": stats.get('visits', 0),
+                 "total_downloads": stats.get('downloads', 0),
+                 "total_entrances": stats.get('entrances', 0)
                  }
             )
-
         return sorted(organization_list, key=lambda organization: organization["total_visits"], reverse=descending)
 
 
@@ -557,28 +566,13 @@ class ResourceStats(Base):
 
     @classmethod
     def get_resource_info_by_id(cls, resource_id):
-        resource = model.Session.query(model.Resource).filter(model.Resource.id == resource_id).first()
-        res_name = None
-        res_package_name = None
-        res_package_id = None
+        resource = get_action('resource_show')({}, {'id': resource_id})
+        package = get_action('package_show')({}, {'id': resource.get('package_id')})
+        result = {'resource_id': resource.get('id'), 'resource_name': resource.get('name'), 'resource_name_translated': resource.get('name_translated'),
+                  'package_id': package.get('id'), 'package_name': package.get('name'), 'package_title': package.get('title'), 'package_title_translated': package.get('title_translated')}
 
-        if resource is not None:
-            res_package_name = resource.package.title or resource.package.name
-            res_package_id = resource.package.name
 
-            name_translated_json = resource.extras.get('name_translated')
-            if name_translated_json is not None:
-                try:
-                    name_translated = json.loads(name_translated_json)
-                    languages = aslist(config.get('ckan.locales_offered', []))
-                    res_name = next((name_translated[lang] for lang in languages
-                                     if name_translated.get(lang)), None)
-                except json.JSONDecodeError:
-                    pass
-
-            res_name = res_name or resource.description or resource.format
-
-        return [res_name, res_package_name, res_package_id]
+        return result
 
     @classmethod
     def get_all_visits_by_id(cls, resource_id):
@@ -591,16 +585,16 @@ class ResourceStats(Base):
         return visits
 
     @classmethod
-    def get_stat_counts_by_id_and_date_range(cls, resource_id,
-                                             start_date=datetime.today() - relativedelta(months=1),
-                                             end_date=datetime.today()):
-        total_visits = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id,
+    def get_stat_counts_by_id_and_date_range(cls, resource_id: str,
+                                             start_date: datetime = datetime.today() - relativedelta(months=1),
+                                             end_date: datetime = datetime.today()) -> Dict[str, int]:
+        total_visits: int = model.Session.query(func.sum(cls.visits)).filter(cls.resource_id == resource_id,
                                                                         cls.visit_date >= start_date,
                                                                         cls.visit_date <= end_date).scalar()
-        total_downloads = model.Session.query(func.sum(cls.downloads)).filter(cls.resource_id == resource_id,
+        total_downloads: int = model.Session.query(func.sum(cls.downloads)).filter(cls.resource_id == resource_id,
                                                                               cls.visit_date >= start_date,
                                                                               cls.visit_date <= end_date).scalar()
-        return {'visits': total_visits, 'downloads': total_downloads}
+        return {'visits': total_visits or 0, 'downloads': total_downloads or 0}
 
     @classmethod
     def get_top(cls, limit=20):
@@ -630,36 +624,26 @@ class ResourceStats(Base):
 
     @classmethod
     def get_top_downloaded_resources_for_organization(cls, organization, start_date, end_date):
-        # Query for organization specific resource ids
-        unique_resources = (model.Session.query(
-            cls.resource_id
-        ).filter(
-            model.Resource.id == cls.resource_id,
-            model.Package.id == model.Resource.package_id,
-            model.Package.state == 'active',
-            model.Resource.state == 'active',
-            model.Group.id == model.Package.owner_org,
-            model.Group.type == 'organization',
-            model.Group.name == organization,
-            model.Group.approval_status == 'approved',
-            cls.visit_date >= start_date,
-            cls.visit_date <= end_date)
-            .distinct()
-            .order_by(cls.resource_id)
-            .all())
+        org_id = get_action('organization_show')({}, {'id': organization}).get('id')
+        fq = 'owner_org:%s' % org_id
+        packages = get_action('package_search')({}, {'fq': fq}).get('results', [])
+        resources = []
+        for pkg in packages:
+            resource_list = pkg.get('resources', [])
+            for resource in resource_list:
+                resources.append(resource.get('id'))
+
         resource_stats = []
         # Add last date associated to the resource stat
-        if unique_resources:
-            for resource in unique_resources:
-                resource_id = resource[0]
-                stats = ResourceStats.get_stat_counts_by_id_and_date_range(resource_id, start_date, end_date)
-                last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.resource_id == resource_id,
-                                                                                 cls.visit_date >= start_date,
-                                                                                 cls.visit_date <= end_date).first()
+        for resource_id in resources:
+            stats = ResourceStats.get_stat_counts_by_id_and_date_range(resource_id, start_date, end_date)
+            last_date = model.Session.query(func.max(cls.visit_date)).filter(cls.resource_id == resource_id,
+                                                                             cls.visit_date >= start_date,
+                                                                             cls.visit_date <= end_date).first()[0]
 
-                rs = ResourceStats(resource_id=resource_id, visit_date=last_date[0],
-                                   visits=stats['visits'], downloads=stats['downloads'])
-                resource_stats.append(rs)
+            rs = ResourceStats(resource_id=resource_id, visit_date=last_date,
+                               visits=stats['visits'], downloads=stats['downloads'])
+            resource_stats.append(rs)
         dictat = ResourceStats.convert_to_dict(resource_stats, None, None)
         dictat['resources'] = sorted(dictat['resources'], key=lambda resource: resource["downloads"], reverse=True)
 
@@ -669,18 +653,23 @@ class ResourceStats(Base):
     def as_dict(cls, res):
         result = {}
         res_info = ResourceStats.get_resource_info_by_id(res.resource_id)
-        result['resource_name'] = res_info[0]
-        result['resource_id'] = res.resource_id
-        result['package_name'] = res_info[1]
-        result['package_id'] = res_info[2]
+        result['resource_id'] = res_info['resource_id']
+        result['resource_name'] = res_info['resource_name']
+        result['resource_name_translated'] = res_info['resource_name_translated']
+        result['package_id'] = res_info['package_id']
+        result['package_name'] = res_info['package_name']
+        result['package_title'] = res_info['package_title']
+        result['package_title_translated'] = res_info['package_title_translated']
         result['visits'] = res.visits
         result['downloads'] = res.downloads
-        result['visit_date'] = res.visit_date.strftime("%d-%m-%Y")
+        result['visit_date'] = res.visit_date.strftime("%d-%m-%Y") if res.visit_date else ''
+
         return result
 
     @classmethod
     def convert_to_dict(cls, resource_stats, tot_visits, total_downloads):
         visits = []
+
         for resource in resource_stats:
             visits.append(ResourceStats.as_dict(resource))
 

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -161,7 +161,9 @@ def matomo_resource_report(organization, time):
 
     # Return matomo_organizations_with_most_popular_datasets list if an organization is not given
     if organization is None:
-        return matomo_organizations_with_most_popular_datasets(time)
+        most_viewed_datasets = matomo_organizations_with_most_popular_datasets(time)
+
+        return {'table': sorted(most_viewed_datasets['table'], key=lambda organization: organization["total_downloads"], reverse=True)}
 
     start_date, end_date = last_calendar_period(time)
 

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -163,7 +163,9 @@ def matomo_resource_report(organization, time):
     if organization is None:
         most_viewed_datasets = matomo_organizations_with_most_popular_datasets(time)
 
-        return {'table': sorted(most_viewed_datasets['table'], key=lambda organization: organization["total_downloads"], reverse=True)}
+        return {'table': sorted(most_viewed_datasets['table'],
+                                key=lambda organization: organization["total_downloads"],
+                                reverse=True)}
 
     start_date, end_date = last_calendar_period(time)
 

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -32,8 +32,11 @@
     </tr>
         {% for resource in table %}
       <tr>
-        <td>{{ h.link_to(h.truncate(resource.resource_name, length=50,whole_word=True), h.url_for('dataset_resource.read',id=resource.package_id,resource_id=resource.resource_id)) }}<br />
-          <em>in {{ h.link_to(resource.package_name, h.url_for('dataset.read', id=resource.package_id)) }}</em>
+        {% set resource_name = h.get_translated(resource, 'resource_name') or resource_name %}
+        {% set package_title = h.get_translated(resource, 'package_title') or package_name %}
+
+        <td>{{ h.link_to(h.truncate(resource_name, length=50,whole_word=True), h.url_for('dataset_resource.read',id=resource.package_id,resource_id=resource.resource_id)) }}<br />
+          <em>in {{ h.link_to(package_title, h.url_for('dataset.read', id=resource.package_id)) }}</em>
         </td>
         <td>{{ resource.downloads }}</td>
         <td>{{ resource.visit_date }}</td>

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+select = ["E", "F"]
+
+extend-exclude = [
+  "ckanext-spatial",
+  "ckanext-prh_tools",
+  "ckanext-dcat",
+  "ckanext-fluent",
+  "ckanext-sitesearch",
+  "ckanext-scheming",
+  "ckanext-ytp_comments"
+]
+
+line-length = 127
+


### PR DESCRIPTION
I got a bit carried away with this so these fix 2 tickets:
[AV-1970](https://jira.dvv.fi/browse/AV-1970) & [AV-1854](https://jira.dvv.fi/browse/AV-1854)

* AV-1970 - List all organizations that have packages (regardless of whether they have visits or downloads in the selected time period or not) on the reports that are grouped by organization (most & least viewed datasets, most downloaded resources)
* AV-1970 - List all datasets of selected organization (regardless of whether they have any visits in the selected time period or not) for most and least viewed datasets (and sort them accordingly)
* AV-1970 & AV-1854 - List all resources of selected organization (regardless of whether they have any visits in the selected time period or not) for most downloaded resources (and sort them accordingly)
* Switched linting to Ruff
* Dropped py2 tests