### PR TITLE
AV-2022: Add api requests count to resources report

### DIFF
--- a/ckanext/matomo/matomo_api.py
+++ b/ckanext/matomo/matomo_api.py
@@ -62,8 +62,7 @@ class MatomoAPI(object):
                          'period': period,
                          'date': date,
                          'flat': 1,
-                         'filter_column': 'label',
-                         'filter_pattern': '/data/([^/]+/)?dataset/[^/]+$'})
+                         'filter_column': 'label'})
 
         def handle(data) -> Dict[str, Any]:
             result: Dict[str, Any] = {}
@@ -119,13 +118,18 @@ class MatomoAPI(object):
 
         return _process_one_or_more_dates_result(data, handle)
 
-    def events(self, period='month', date='today') -> Dict[str, Any]:
+    def events(self, period='month', date='today', filter_column='Events_EventAction', filter_pattern=None) -> Dict[str, Any]:
+        filter = {
+            'filter_column': filter_column,
+        }
+        if filter_pattern:
+            filter['filter_pattern'] = filter_pattern
         data: Dict[str, Any] = self.get({'method': 'Events.getAction',
                          'period': period,
                          'date': date,
-                         'filter_column': 'Events_EventAction',
-                         'filter_pattern': '^package_show',
-                         'flat': 1})
+                         'flat': 1,
+                        'filter_limit': -1,
+                         **filter})
 
         def handle(data) -> Dict[str, Any]:
             return data

--- a/ckanext/matomo/migration/matomo/versions/ec140de715f6_add_events_field_for_resource_stats.py
+++ b/ckanext/matomo/migration/matomo/versions/ec140de715f6_add_events_field_for_resource_stats.py
@@ -1,0 +1,35 @@
+"""Add events field for resource_stats
+
+Revision ID: ec140de715f6
+Revises: c2aea25862a9
+Create Date: 2023-07-05 14:14:07.852722
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ec140de715f6'
+down_revision = 'c2aea25862a9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not column_exists('resource_stats', 'events'):
+        op.add_column('resource_stats', sa.Column('events', sa.Integer, default=0))
+    pass
+
+
+def downgrade():
+    op.drop_column('resource_stats', 'events')
+    pass
+
+
+def column_exists(table_name, column_name):
+    bind = op.get_context().bind
+    insp = sa.inspect(bind)
+    columns = insp.get_columns(table_name)
+    return any(c["name"] == column_name for c in columns)
+    pass

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -35,44 +35,73 @@ def org_and_time_option_combinations() -> Generator[OrganizationAndTimeOptions, 
 def matomo_organization_list(start_date: datetime,
                              end_date: datetime,
                              descending=True,
-                             sort_by="visits") -> List[VisitsByOrganization]:
+                             sort_by="visits",
+                             count="dataset") -> List[VisitsByOrganization]:
     # Fetch all organizations which have at least 1 dataset
     organizations_with_datasets = report.get_all_organizations(
         only_orgs_with_packages=True)
-    # Fetch total visits per package within given date range
-    package_stats: List[VisitsByPackage] = PackageStats.get_total_visits(
-        start_date, end_date, descending)
 
-    # Count org specific sums
+
     totals_by_organization: GroupedVisits = {}
-    for stat in package_stats:
-        organization_id: Optional[str] = stat.get('owner_org', None)
-        if organization_id:
-            is_new = not bool(totals_by_organization.get(organization_id))
-            if is_new:
-                totals_by_organization[organization_id] = {}
-            totals_by_organization[organization_id]['visits'] = totals_by_organization[organization_id].get(
-                'visits', 0) + stat.get('visits', 0)
-            totals_by_organization[organization_id]['entrances'] = totals_by_organization[organization_id].get(
-                'entrances', 0) + stat.get('entrances', 0)
-            totals_by_organization[organization_id]['downloads'] = totals_by_organization[organization_id].get(
-                'downloads', 0) + stat.get('downloads', 0)
-            totals_by_organization[organization_id]['events'] = totals_by_organization[organization_id].get(
-                'events', 0) + stat.get('events', 0)
+    if count == 'dataset':
+        # Fetch total visits per dataset within given date range
+        package_stats: List[VisitsByPackage] = PackageStats.get_total_visits(
+            start_date, end_date, descending)
+
+        # Count org specific sums
+        for stat in package_stats:
+            organization_id: Optional[str] = stat.get('owner_org', None)
+            if organization_id:
+                is_new = not bool(totals_by_organization.get(organization_id))
+                if is_new:
+                    totals_by_organization[organization_id] = {}
+                totals_by_organization[organization_id]['visits'] = totals_by_organization[organization_id].get(
+                    'visits', 0) + stat.get('visits', 0)
+                totals_by_organization[organization_id]['entrances'] = totals_by_organization[organization_id].get(
+                    'entrances', 0) + stat.get('entrances', 0)
+                totals_by_organization[organization_id]['downloads'] = totals_by_organization[organization_id].get(
+                    'downloads', 0) + stat.get('downloads', 0)
+                totals_by_organization[organization_id]['events'] = totals_by_organization[organization_id].get(
+                    'events', 0) + stat.get('events', 0)
+
+    elif count == 'resource':
+        # Fetch total visits per resource within given date range
+        resource_stats: List[VisitsByResource] = ResourceStats.get_total_downloads(
+            start_date, end_date, descending)
+
+        # Count org specific sums
+        log.debug(resource_stats)
+        for stat in resource_stats:
+            organization_id: Optional[str] = stat.get('owner_org', None)
+            if organization_id:
+                is_new = not bool(totals_by_organization.get(organization_id))
+                if is_new:
+                    totals_by_organization[organization_id] = {}
+                totals_by_organization[organization_id]['visits'] = totals_by_organization[organization_id].get(
+                    'visits', 0) + stat.get('visits', 0)
+                totals_by_organization[organization_id]['downloads'] = totals_by_organization[organization_id].get(
+                    'downloads', 0) + stat.get('downloads', 0)
+                totals_by_organization[organization_id]['events'] = totals_by_organization[organization_id].get(
+                    'events', 0) + stat.get('events', 0)
+
     # Format into list of org dicts with stats totals
     organizations: List[VisitsByOrganization] = []
     for organization in organizations_with_datasets:
         org_id: str = organization.get('id', '')
         stats = totals_by_organization.get(org_id, {})
-        organizations.append({
+        org: VisitsByOrganization = {
             "organization_name": organization.get('name', ''),
             "organization_title": organization.get('title', ''),
             "organization_title_translated": organization.get('title_translated'),
             "visits": stats.get('visits', 0),
             "downloads": stats.get('downloads', 0),
-            "entrances": stats.get('entrances', 0),
             "events": stats.get('events', 0)
-        })
+        }
+
+        if count == 'dataset':
+            org['entrances'] = stats.get('entrances', 0)
+
+        organizations.append(org)
 
     return sorted(organizations, key=lambda organization: organization[sort_by], reverse=descending)
 
@@ -133,7 +162,7 @@ def matomo_dataset_report(organization: str, time: str) -> Dict[str, Any]:
     if organization_name is None:
         return {
             'report_name': 'matomo-dataset',
-            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='visits')
+            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='visits', count='dataset')
         }
     else:
         # get given organizations datasets with the popularity statistics
@@ -177,6 +206,7 @@ def matomo_resources_by_organization(organization_name: str,
     visits_by_resource: GroupedVisits = {
         res.get('resource_id', ''): {'visits': res.get('visits', 0),
                                      'downloads': res.get('downloads', 0),
+                                     'events': res.get('events', 0),
                                      'visit_date': res.get('visit_date', '')}
         for res in resource_stats}
 
@@ -195,6 +225,7 @@ def matomo_resources_by_organization(organization_name: str,
                  'owner_org': package.get('owner_org'),
                  'visits': visit.get('visits', 0),
                  'downloads': visit.get('downloads', 0),
+                 'events': visit.get('events', 0),
                  'visit_date': visit.get('visit_date', '')})
 
     return sorted(result, key=lambda dataset: dataset[sort_by], reverse=descending)
@@ -213,7 +244,7 @@ def matomo_resource_report(organization: str, time: str) -> Report:
     if organization_name is None:
         return {
             'report_name': 'matomo-resource',
-            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='downloads')
+            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='downloads', count='resource')
         }
 
     return {

--- a/ckanext/matomo/reports.py
+++ b/ckanext/matomo/reports.py
@@ -36,14 +36,14 @@ def matomo_organization_list(start_date: datetime,
                              end_date: datetime,
                              descending=True,
                              sort_by="visits",
-                             count="dataset") -> List[VisitsByOrganization]:
+                             report_type="dataset") -> List[VisitsByOrganization]:
     # Fetch all organizations which have at least 1 dataset
     organizations_with_datasets = report.get_all_organizations(
         only_orgs_with_packages=True)
 
 
     totals_by_organization: GroupedVisits = {}
-    if count == 'dataset':
+    if report_type == 'dataset':
         # Fetch total visits per dataset within given date range
         package_stats: List[VisitsByPackage] = PackageStats.get_total_visits(
             start_date, end_date, descending)
@@ -64,13 +64,12 @@ def matomo_organization_list(start_date: datetime,
                 totals_by_organization[organization_id]['events'] = totals_by_organization[organization_id].get(
                     'events', 0) + stat.get('events', 0)
 
-    elif count == 'resource':
+    elif report_type == 'resource':
         # Fetch total visits per resource within given date range
         resource_stats: List[VisitsByResource] = ResourceStats.get_total_downloads(
             start_date, end_date, descending)
 
         # Count org specific sums
-        log.debug(resource_stats)
         for stat in resource_stats:
             organization_id: Optional[str] = stat.get('owner_org', None)
             if organization_id:
@@ -98,7 +97,7 @@ def matomo_organization_list(start_date: datetime,
             "events": stats.get('events', 0)
         }
 
-        if count == 'dataset':
+        if report_type == 'dataset':
             org['entrances'] = stats.get('entrances', 0)
 
         organizations.append(org)
@@ -162,7 +161,7 @@ def matomo_dataset_report(organization: str, time: str) -> Dict[str, Any]:
     if organization_name is None:
         return {
             'report_name': 'matomo-dataset',
-            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='visits', count='dataset')
+            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='visits', report_type='dataset')
         }
     else:
         # get given organizations datasets with the popularity statistics
@@ -244,7 +243,8 @@ def matomo_resource_report(organization: str, time: str) -> Report:
     if organization_name is None:
         return {
             'report_name': 'matomo-resource',
-            'table': matomo_organization_list(start_date, end_date, descending=True, sort_by='downloads', count='resource')
+            'table': matomo_organization_list(start_date, end_date, descending=True,
+                                              sort_by='downloads', report_type='resource')
         }
 
     return {

--- a/ckanext/matomo/templates/report/resource_analytics.html
+++ b/ckanext/matomo/templates/report/resource_analytics.html
@@ -9,6 +9,7 @@
       <tr>
         <th>{% trans %}Organization{% endtrans %}</th>
         <th>{% trans %}Downloads{% endtrans %}</th>
+        <th>{% trans %}API events{% endtrans %}</th>
       </tr>
         {% for row in data['table'] %}
           {% set org_name = row.get('organization_name') %}
@@ -16,6 +17,7 @@
           <tr>
             <td>{{ h.link_to(org_title, h.get_organization_url(org_name)) }}</td>
             <td>{{ row.get('downloads') }}</td>
+            <td>{{ row.get('events') }}</td>
           </tr>
         {% endfor %}
       </table>
@@ -29,6 +31,7 @@
       <th>{% trans %}Resource{% endtrans %}</th>
       <th>{% trans %}Downloads{% endtrans %}&nbsp;({{ _(options['time']) }})</th>
       <th>{% trans %}Last accessed date{% endtrans %}</th>
+      <th>{% trans %}API events{% endtrans %}</th>
     </tr>
         {% for resource in table %}
       <tr>
@@ -40,6 +43,7 @@
         </td>
         <td>{{ resource.get('downloads') }}</td>
         <td>{{ resource.get('visit_date') }}</td>
+        <td>{{ resource.get('events') }}</td>
       </tr>
       {% endfor %}
       </table>

--- a/ckanext/matomo/types.py
+++ b/ckanext/matomo/types.py
@@ -30,15 +30,16 @@ VisitsByOrganization = TypedDict('VisitsByOrganization', {
     'organization_name': str,
     'organization_title': str,
     'organization_title_translated': Optional[LocalizationObject],
-    'visits': int,
-    'entrances': int,
+    'visits': Optional[int],
+    'entrances': Optional[int],
     'downloads': int,
     'events': int
-})
+}, total=False)
 GroupedVisits = Dict[str, Visit]
 Report = TypedDict('Report', {'report_name': str,
                    'table': Union[List[VisitsByOrganization], List[VisitsByPackage], List[VisitsByResource]]}, total=False)
 Resource = TypedDict('Resource', {'resource_id': str, 'resource_name': str,
                                   'resource_name_translated': Optional[LocalizationObject], 'package_id': str,
                                   'package_name': str, 'package_title': str,
-                                  'package_title_translated': Optional[LocalizationObject]})
+                                  'package_title_translated': Optional[LocalizationObject],
+                                  'owner_org': Optional[str]})


### PR DESCRIPTION
Add the number of API calls to resources report (datastore_search_sql queries to a specific resource id) and refactor matomo_organization_list to differentiate between dataset reports and resource reports for correct calculations for the totals now that both resource and dataset reports have events column but they're completely separate information.