### PR TITLE
Make tracking api events and downloads optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,13 @@ Config Settings
     # (optional, default ckanext.matomo.domain)
     ckanext.matomo.script_domain
 
+    # To track api events, set to true
+    ckanext.matomo.track_api = true
+
+    # To track downloads, set to true
+    ckanext.matoto.track_downloads = true
+
+
 ------------------------
 Development Installation
 ------------------------

--- a/ckanext/matomo/commands.py
+++ b/ckanext/matomo/commands.py
@@ -26,7 +26,7 @@ def fetch(dryrun, since, until):
         print('Start date must not be greater than end date')
         return
 
-    matomo_url = toolkit.config.get('ckanext.matomo.domain')
+    matomo_url = toolkit.config.get('ckanext.matomo.api_domain') or toolkit.config.get('ckanext.matomo.domain')
     matomo_site_id = toolkit.config.get('ckanext.matomo.site_id')
     matomo_token_auth = toolkit.config.get('ckanext.matomo.token_auth')
     api = MatomoAPI(matomo_url, matomo_site_id, matomo_token_auth)

--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -12,7 +12,8 @@ def matomo_snippet():
     data = {
         "matomo_domain": config.get('ckanext.matomo.domain'),
         "matomo_script_domain": config.get('ckanext.matomo.script_domain', config.get('ckanext.matomo.domain')),
-        "matomo_site_id": config.get('ckanext.matomo.site_id')
+        "matomo_site_id": config.get('ckanext.matomo.site_id'),
+        "matomo_filename": config.get('ckanext.matomo.filename', "matomo")
     }
 
     return render_snippet("matomo/snippets/matomo.html", data)

--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -13,7 +13,8 @@ def matomo_snippet():
         "matomo_domain": config.get('ckanext.matomo.domain'),
         "matomo_script_domain": config.get('ckanext.matomo.script_domain', config.get('ckanext.matomo.domain')),
         "matomo_site_id": config.get('ckanext.matomo.site_id'),
-        "matomo_filename": config.get('ckanext.matomo.filename', "matomo")
+        "matomo_tracker_filename": config.get('ckanext.matomo.tracker_filename', "matomo.php"),
+        "matomo_script_filename": config.get('ckanext.matomo.script_filename', "matomo.js")
     }
 
     return render_snippet("matomo/snippets/matomo.html", data)

--- a/ckanext/matomo/plugin/flask_plugin.py
+++ b/ckanext/matomo/plugin/flask_plugin.py
@@ -3,7 +3,6 @@ from ckanext.matomo.tracking import post_analytics, tracked_action
 from flask import Blueprint
 from ckan.views.resource import download as resource_download
 
-
 class MixinPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IBlueprint)
 
@@ -17,8 +16,10 @@ class MixinPlugin(plugins.SingletonPlugin):
             # ('/dataset/<package_id>/resource/<resource_id>/download', 'tracked_download', tracked_download),
             # ('/dataset/<package_id>/resource/<resource_id>/download/<filename>', 'tracked_download', tracked_download)
         ]
-        for rule in rules:
-            blueprint.add_url_rule(*rule)
+
+        if plugins.toolkit.asbool(plugins.toolkit.config.get('ckanext.matomo.track_api', False)):
+            for rule in rules:
+                blueprint.add_url_rule(*rule)
 
         return blueprint
 

--- a/ckanext/matomo/plugin/pylons_plugin.py
+++ b/ckanext/matomo/plugin/pylons_plugin.py
@@ -1,35 +1,21 @@
 import ckan.plugins as plugins
 from routes.mapper import SubMapper
 from ckanext.matomo import tracking
-from flask import Blueprint
 from ckan.controllers.package import PackageController
 from ckan.plugins import plugin_loaded
 
 
 class MixinPlugin:
     plugins.implements(plugins.IRoutes, inherit=True)
-    plugins.implements(plugins.IBlueprint)
 
     # IRoutes
 
     def before_map(self, map):
-        with SubMapper(map, controller='ckanext.matomo.plugin.pylons_plugin:TrackedResourceController') as m:
-            m.connect('/dataset/{id}/resource/{resource_id}/download', action='resource_download')
-            m.connect('/dataset/{id}/resource/{resource_id}/download/{filename}', action='resource_download')
+        if plugins.toolkit.asbool(plugins.toolkit.config.get('ckanext.matomo.track_downloads', False)):
+            with SubMapper(map, controller='ckanext.matomo.plugin.pylons_plugin:TrackedResourceController') as m:
+                m.connect('/dataset/{id}/resource/{resource_id}/download', action='resource_download')
+                m.connect('/dataset/{id}/resource/{resource_id}/download/{filename}', action='resource_download')
         return map
-
-    # IBlueprint
-
-    def get_blueprint(self):
-        blueprint = Blueprint('matomo', self.__module__)
-        rules = [
-            ('/api/action/<logic_function>', 'tracked_action', tracking.tracked_action),
-            ('/api/<ver>/action/<logic_function>', 'tracked_action', tracking.tracked_action),
-        ]
-        for rule in rules:
-            blueprint.add_url_rule(*rule)
-
-        return blueprint
 
 
 # Ugly hack since ckanext-cloudstorage replaces resource_download action

--- a/ckanext/matomo/templates/matomo/snippets/matomo.html
+++ b/ckanext/matomo/templates/matomo/snippets/matomo.html
@@ -6,10 +6,10 @@
   _paq.push(['enableLinkTracking']);
   (function() {
     var u="{{ matomo_domain }}";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setTrackerUrl', u+'{{matomo_filename}}.php']);
     _paq.push(['setSiteId', '{{ matomo_site_id }}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='{{ matomo_script_domain }}' + 'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src='{{ matomo_script_domain }}' + '{{matomo_filename}}.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Code -->

--- a/ckanext/matomo/templates/matomo/snippets/matomo.html
+++ b/ckanext/matomo/templates/matomo/snippets/matomo.html
@@ -6,10 +6,10 @@
   _paq.push(['enableLinkTracking']);
   (function() {
     var u="{{ matomo_domain }}";
-    _paq.push(['setTrackerUrl', u+'{{matomo_filename}}.php']);
+    _paq.push(['setTrackerUrl', u+'{{matomo_tracker_filename}}']);
     _paq.push(['setSiteId', '{{ matomo_site_id }}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='{{ matomo_script_domain }}' + '{{matomo_filename}}.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src='{{ matomo_script_domain }}' + '{{matomo_script_filename}}'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Code -->


### PR DESCRIPTION
In a case where you don't want to track events, it should be optional