### PR TITLE
Add indexes and support for fetching analytics data for single dataset

### DIFF
--- a/ckanext/matomo/cli.py
+++ b/ckanext/matomo/cli.py
@@ -21,8 +21,9 @@ def matomo():
 @click.option(u'--dryrun', is_flag=True, help="Prints what would be updated without making any changes.")
 @click.option(u'--since', help="First date to fetch in YYYY-MM-DD format. Default: latest PackageStats entry date.")
 @click.option(u'--until', help="Last date to fetch in YYYY-MM-DD format. Default: current date.")
-def fetch(dryrun, since, until):
-    commands.fetch(dryrun, since, until)
+@click.option(u'--dataset', required=False, help="Fetch analytics data for a single dataset")
+def fetch(dryrun, since, until, dataset):
+    commands.fetch(dryrun, since, until, dataset)
 
 
 @matomo.command(

--- a/ckanext/matomo/commands.py
+++ b/ckanext/matomo/commands.py
@@ -10,7 +10,7 @@ DATE_FORMAT = '%Y-%m-%d'
 
 log = __import__('logging').getLogger(__name__)
 
-def fetch(dryrun, since, until):
+def fetch(dryrun, since, until, dataset):
     if since:
         since_date = datetime.datetime.strptime(since, DATE_FORMAT).date()
     else:
@@ -36,8 +36,8 @@ def fetch(dryrun, since, until):
 
     # Dataset stats
 
-    dataset_page_statistics: Dict[str, Any] = api.dataset_page_statistics(**params)
-    resource_download_statistics: Dict[str, Any] = api.resource_download_statistics(**params)
+    dataset_page_statistics: Dict[str, Any] = api.dataset_page_statistics(**params, dataset=dataset)
+    resource_download_statistics: Dict[str, Any] = api.resource_download_statistics(**params, dataset=dataset)
     package_show_events: Dict[str, Any] = api.events(**params, filter_pattern='package_show')
 
     updated_package_ids_by_date = {}
@@ -141,6 +141,8 @@ def fetch(dryrun, since, until):
             regex = re.compile('.*id=([a-zA-Z0-9-_]*)&?.*$', re.I)
             match = regex.match(stats.get('Events_EventName'))
             if match and match[1]:
+                if dataset and dataset is not match[1]:
+                    continue
                 package_id_or_name = match[1]
                 try:
                     package = package_show({'ignore_auth': True}, {'id': package_id_or_name})
@@ -206,41 +208,42 @@ def fetch(dryrun, since, until):
                 except Exception as e:
                     log.exception('Error updating API event statistics for resource {}: {}'.format(resource_id, e))
 
-    # Visits by country
-    visits_by_country = api.visits_by_country(**params)
+    if not dataset:
+        # Visits by country
+        visits_by_country = api.visits_by_country(**params)
 
-    for date_str, date_statistics in visits_by_country.items():
-        date = datetime.datetime.strptime(date_str, DATE_FORMAT)
-        for country_stats in date_statistics:
-            country_name = country_stats.get('label', '(not set)')
-            visits = country_stats.get('nb_visits', 0)
+        for date_str, date_statistics in visits_by_country.items():
+            date = datetime.datetime.strptime(date_str, DATE_FORMAT)
+            for country_stats in date_statistics:
+                country_name = country_stats.get('label', '(not set)')
+                visits = country_stats.get('nb_visits', 0)
 
-            try:
-                if dryrun:
-                    log.info("Would update country statistics: date={}, country={}, visits={}"
-                          .format(date, country_name, visits))
-                else:
-                    AudienceLocationDate.update_visits(country_name, date, visits)
-            except Exception as e:
-                log.exception('Error updating country statistics for {}: {}'.format(country_name, e))
+                try:
+                    if dryrun:
+                        log.info("Would update country statistics: date={}, country={}, visits={}"
+                              .format(date, country_name, visits))
+                    else:
+                        AudienceLocationDate.update_visits(country_name, date, visits)
+                except Exception as e:
+                    log.exception('Error updating country statistics for {}: {}'.format(country_name, e))
 
-    # Search terms
-    search_terms = api.search_terms(**params)
+        # Search terms
+        search_terms = api.search_terms(**params)
 
-    for date_str, date_statistics in search_terms.items():
-        date = datetime.datetime.strptime(date_str, DATE_FORMAT)
-        for search_term_stats in date_statistics:
-            search_term = search_term_stats.get('label', '(not set)')
-            count = search_term_stats.get('nb_visits', 0)
+        for date_str, date_statistics in search_terms.items():
+            date = datetime.datetime.strptime(date_str, DATE_FORMAT)
+            for search_term_stats in date_statistics:
+                search_term = search_term_stats.get('label', '(not set)')
+                count = search_term_stats.get('nb_visits', 0)
 
-            try:
-                if dryrun:
-                    log.info("Would search term statistics: date={}, search_term={}, count={}"
-                          .format(date, search_term, count))
-                else:
-                    SearchStats.update_search_term_count(search_term, date, count)
-            except Exception as e:
-                log.exception('Error updating search term statistics for {}: {}'.format(search_term, e))
+                try:
+                    if dryrun:
+                        log.info("Would search term statistics: date={}, search_term={}, count={}"
+                              .format(date, search_term, count))
+                    else:
+                        SearchStats.update_search_term_count(search_term, date, count)
+                except Exception as e:
+                    log.exception('Error updating search term statistics for {}: {}'.format(search_term, e))
 
 
 def init_db():

--- a/ckanext/matomo/commands.py
+++ b/ckanext/matomo/commands.py
@@ -111,8 +111,8 @@ def fetch(dryrun, since, until, dataset):
                     try:
                         downloads = sum(int(stats.get('nb_hits', 0)) for stats in resource_stats)
                         if dryrun:
-                            log.info('Would create or update: resource_id={}, date={}, downloads={}'
-                                  .format(resource_id, date, downloads))
+                            log.info('Would create or update: package_id={}, resource_id={}, date={}, downloads={}'
+                                  .format(package_id, resource_id, date, downloads))
                         else:
                             ResourceStats.update_downloads(resource_id, date, downloads)
                     except Exception as e:

--- a/ckanext/matomo/matomo_api.py
+++ b/ckanext/matomo/matomo_api.py
@@ -36,13 +36,17 @@ class MatomoAPI(object):
 
         return result
 
-    def resource_download_statistics(self, period='month', date='today') -> Dict[str, Any]:
+    def resource_download_statistics(self, period='month', date='today', dataset=None) -> Dict[str, Any]:
+        pattern = '/data/([^/]+/)?dataset/[^/]+/resource/[^/]+/download/[^/]+$'
+        if dataset:
+            pattern = '/data/([^/]+/)?dataset/{dataset}/resource/[^/]+/download/[^/]+$'.format(dataset=dataset)
+
         data: Dict[str, Any] = self.get({'method': 'Actions.getDownloads',
                          'period': period,
                          'date': date,
                          'flat': 1,
                          'filter_column': 'label',
-                         'filter_pattern': '/data/([^/]+/)?dataset/[^/]+/resource/[^/]+/download/[^/]+$'})
+                         'filter_pattern': pattern })
 
         def handle(data) -> Dict[str, Any]:
             result: Dict[str, Any] = {}
@@ -57,12 +61,18 @@ class MatomoAPI(object):
 
         return _process_one_or_more_dates_result(data, handle)
 
-    def dataset_page_statistics(self, period='month', date='today') -> Dict[str, Any]:
+    def dataset_page_statistics(self, period='month', date='today', dataset=None) -> Dict[str, Any]:
+        # TODO: /data/ should be config based, fine for our projects for now
+        pattern = '[^/]*/data/([^/]+/)?dataset/[^/]+$'
+        if dataset:
+            pattern = '[^/]*/data/([^/]+/)?dataset/{dataset}$'.format(dataset=dataset)
+
         data: Dict[str, Any] = self.get({'method': 'Actions.getPageUrls',
                          'period': period,
                          'date': date,
                          'flat': 1,
-                         'filter_column': 'label'})
+                         'filter_column': 'label',
+                         'filter_pattern': pattern})
 
         def handle(data) -> Dict[str, Any]:
             result: Dict[str, Any] = {}
@@ -76,13 +86,17 @@ class MatomoAPI(object):
 
         return _process_one_or_more_dates_result(data, handle)
 
-    def resource_page_statistics(self, period='month', date='today') -> Dict[str, Any]:
+    def resource_page_statistics(self, period='month', date='today', dataset=None) -> Dict[str, Any]:
+        pattern = '[^/]*/data/([^/]+/)?dataset/[^/]+/resource/[^/]+$'
+        if dataset:
+            pattern = '[^/]*/data/([^/]+/)?dataset/{dataset}/resource/[^/]+$'.format(dataset=dataset)
+
         data: Dict[str, Any] = self.get({'method': 'Actions.getPageUrls',
                          'period': period,
                          'date': date,
                          'flat': 1,
                          'filter_column': 'label',
-                         'filter_pattern': '[^/]*/data/([^/]+/)?dataset/[^/]+/resource/[^/]+$'})
+                         'filter_pattern': pattern})
 
         def handle(data) -> Dict[str, Any]:
             result: Dict[str, Any] = {}

--- a/ckanext/matomo/migration/matomo/versions/299beffac30a_add_indexes_to_search_terms_table.py
+++ b/ckanext/matomo/migration/matomo/versions/299beffac30a_add_indexes_to_search_terms_table.py
@@ -1,0 +1,27 @@
+"""Add indexes to search terms table
+
+Revision ID: 299beffac30a
+Revises: ec140de715f6
+Create Date: 2024-02-01 13:13:27.201693
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '299beffac30a'
+down_revision = 'ec140de715f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_search_terms_id', 'search_terms', ['id'], unique=True, if_not_exists=True)
+    op.create_index('ix_search_terms_date', 'search_terms', ['date'], if_not_exists=True)
+    pass
+
+
+def downgrade():
+    op.drop_index('ix_search_terms_id', 'search_terms')
+    op.drop_index('ix_search_terms_date', 'search_terms')
+    pass


### PR DESCRIPTION
Adds indexes for search terms table with migration.
Add cli support to fetch analytics data for only single dataset.
Uses filter pattern in dataset page views for pre-filterning non-dataset urls.