### PR TITLE
Optimize resource download graph not to fetch all data

### DIFF
--- a/ckanext/matomo/helpers.py
+++ b/ckanext/matomo/helpers.py
@@ -1,10 +1,10 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from flask import request
 from typing import List, Tuple, Optional
 from ckan.plugins.toolkit import render_snippet, config
 from ckan.plugins import toolkit as tk
 from ckanext.matomo.reports import last_calendar_period, get_report_years
-from ckanext.matomo.model import PackageStats, ResourceStats
+from ckanext.matomo.model import PackageStats, ResourceStats, get_end_of_last_week, get_beginning_of_next_week
 from ckanext.matomo.types import Visits
 
 
@@ -39,6 +39,11 @@ def get_visits_for_dataset(id: str) -> Visits:
 def get_visits_for_resource(id: str) -> Visits:
     return ResourceStats.get_all_visits(id)
 
+def get_downloads_in_date_range_for_resource(id: str) -> Visits:
+    end_of_last_week = get_end_of_last_week(datetime.now())
+    start_date = get_beginning_of_next_week(end_of_last_week.replace(hour=0, minute=0, second=0, microsecond=0)
+                                            - timedelta(days=365))
+    return ResourceStats.get_downloads_in_date_range_by_id(id, start_date, end_of_last_week)
 
 def get_download_count_for_dataset(id: str, time: str) -> int:
     start_date, end_date = get_date_range(time)

--- a/ckanext/matomo/plugin/__init__.py
+++ b/ckanext/matomo/plugin/__init__.py
@@ -73,7 +73,8 @@ class MatomoPlugin(MixinPlugin, plugins.SingletonPlugin, DefaultTranslation):
             'get_date_range': helpers.get_date_range,
             'get_years': helpers.get_years,
             'matomo_show_download_graph': helpers.show_download_graph,
-            'get_current_date': helpers.get_current_date
+            'get_current_date': helpers.get_current_date,
+            'get_downloads_in_date_range_for_resource': helpers.get_downloads_in_date_range_for_resource
         }
 
     # IClick

--- a/ckanext/matomo/templates/matomo/snippets/resource_stats.html
+++ b/ckanext/matomo/templates/matomo/snippets/resource_stats.html
@@ -7,7 +7,7 @@
     <div id="chart_div"></div>
     {% endif %}
   
-    {% set visits =  h.get_visits_for_resource(res.id) %}
+    {% set visits =  h.get_downloads_in_date_range_for_resource(res.id) %}
     {% set visit_count_last_12_month = h.get_visit_count_for_resource(res.id, 'year') %}
     {% set visit_count_last_30_days = h.get_visit_count_for_resource(res.id, 'month') %}
     {% set download_count_last_12_month = h.get_download_count_for_resource(res.id, 'year') %}


### PR DESCRIPTION
The graph does not need all the data since it only shows the past year.