### PR TITLE
AV-2184: Remove bulk event sending as it is not supported

### DIFF
--- a/ckanext/matomo/matomo_api.py
+++ b/ckanext/matomo/matomo_api.py
@@ -2,7 +2,6 @@ import requests
 import datetime
 import uuid
 
-from urllib.parse import urlencode
 from typing import Dict, Any
 
 log = __import__('logging').getLogger(__name__)
@@ -168,22 +167,6 @@ class MatomoAPI(object):
             params['token_auth'] = self.token_auth
 
         return requests.get(self.tracking_url, params=params)
-
-    def tracking_bulk(self, events, token_auth=None):
-        # URL encode events as required by Matomo:
-        # https://developer.matomo.org/api-reference/tracking-api#bulk-tracking
-        requests = []
-        for event in events:
-            params = self.tracking_params.copy()
-            params.update(event)
-            requests.append(f'?{urlencode(params)}')
-
-        data = {
-            'requests': requests,
-            'token_auth': token_auth or self.token_auth
-        }
-
-        return requests.post(self.tracking_url, data=data)
 
 
 def _process_one_or_more_dates_result(data, handler) -> Dict[str, Any]:


### PR DESCRIPTION
- Bulk sending is apprently not functional for the kind of events we send for API requests, so use regular tracking