### PR TITLE
AV-2247: if there is a dnt header, supply it in api tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     name: CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container:
-      image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
+      image: ckan/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,13 @@ jobs:
           ckan -c test.ini matomo init_db
       - name: Run tests
         run: pytest --ckan-ini=test.ini --cov=ckanext.matomo --disable-warnings ckanext/matomo/tests
+
+      - name: install codecov requirements
+        run: |
+          apk add gpg gpg-agent
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          os: alpine

--- a/ckanext/matomo/matomo_api.py
+++ b/ckanext/matomo/matomo_api.py
@@ -168,7 +168,6 @@ class MatomoAPI(object):
         if self.token_auth is not None:
             params['token_auth'] = self.token_auth
 
-        log.info(extra_headers)
         return requests.get(self.tracking_url, params=params, headers=extra_headers)
 
 

--- a/ckanext/matomo/matomo_api.py
+++ b/ckanext/matomo/matomo_api.py
@@ -158,7 +158,9 @@ class MatomoAPI(object):
             end = end.strftime('%Y-%m-%d')
         return '{},{}'.format(start, end)
 
-    def tracking(self, extra_params):
+    def tracking(self, extra_params, extra_headers=None):
+        if extra_headers is None:
+            extra_headers = {}
         params = self.tracking_params.copy()
         params.update(extra_params)
         params['rand'] = str(uuid.uuid4())
@@ -166,7 +168,8 @@ class MatomoAPI(object):
         if self.token_auth is not None:
             params['token_auth'] = self.token_auth
 
-        return requests.get(self.tracking_url, params=params)
+        log.info(extra_headers)
+        return requests.get(self.tracking_url, params=params, headers=extra_headers)
 
 
 def _process_one_or_more_dates_result(data, handler) -> Dict[str, Any]:


### PR DESCRIPTION
If there is an do not track header in the request, supply it with the event to matomo, will break when browsers or matomo removes dnt support.