### PR TITLE
AV-2287: Add missing translations to location report labels

### DIFF
--- a/ckanext/matomo/templates/report/location_analytics.html
+++ b/ckanext/matomo/templates/report/location_analytics.html
@@ -8,7 +8,7 @@
       {% for row in data['data']['finland_vs_world_last_month'] %}
         {
           value: {{ row.total_visits or 0}},
-          label: '{{ row.location_name }}'
+          label: '{{ _(row.location_name) }}'
         },
       {% endfor %}
     ],
@@ -16,7 +16,7 @@
       {% for row in data['data']['finland_vs_world_all'] %}
         {
           value: {{ row.total_visits }},
-          label: '{{ row.location_name }}'
+          label: '{{ _(row.location_name) }}'
         },
       {% endfor %}
     ],

--- a/ckanext/matomo/translations.py
+++ b/ckanext/matomo/translations.py
@@ -14,6 +14,8 @@ def _translations():
     _("Matomo showing most popular search terms")
     _("Last searched date")
 
+    _('Other')
+
     _('Andorra')
     _('United Arab Emirates')
     _('Afghanistan')


### PR DESCRIPTION
- Some country names in chart labels were not translated, add translations
- Make 'Other' label translatable